### PR TITLE
Updated 4diac IDE build instructions

### DIFF
--- a/src/development/building4diac.asciidoc
+++ b/src/development/building4diac.asciidoc
@@ -87,7 +87,7 @@ Note: If you get an error in the "Problems" view stating "There is a possible AP
 
 . Expand the project `org.eclipse.fordiac.ide.product` and open the target configuration `org.eclipse.fordiac.ide.product.target`:
 +
-image:./TargetPlatform.png[Eclipse target platform configuration]
+image:./img/TargetPlatform.png[Eclipse target platform configuration]
 . Wait until the target platform is resolved or press [.button4diac]#Reload# and wait until it is resolved
 . Press [.button4diac]#Set as Active Target Platform# within the upper right corner and wait until the workspace is built.
 

--- a/src/development/building4diac.asciidoc
+++ b/src/development/building4diac.asciidoc
@@ -79,9 +79,9 @@ of the preferences window from Error to Ignore
 +
 image:./img/APIbaseline.png[API Baseline]
 
-----
+
 Note: If you get an error in the "Problems" view stating "There is a possible API baseline mismatch ...", you can safely ignore this message. This message will not prevent the IDE from building successfully.
-----
+
 
 === [[targetPlatform]]Set Target Platform
 

--- a/src/development/building4diac.asciidoc
+++ b/src/development/building4diac.asciidoc
@@ -48,7 +48,7 @@ The code will be copied to the new created folder
 You can also use the git integrated into Eclipse for this process.
 Please refer to the Eclipse EGit documentation on how to clone a repository.
 
-Once you have cloned the repository make sure that you switch to the `develop` branch. Thhe default branch, `master`, might be out of date and thus incompatible with these setup steps.
+Once you have cloned the repository make sure that you switch to the `develop` branch. The default branch, `master`, might be out of date and thus incompatible with these setup steps.
 ----
 $ cd ~/org.eclipse.4diac.ide/
 $ git checkout develop

--- a/src/development/building4diac.asciidoc
+++ b/src/development/building4diac.asciidoc
@@ -30,7 +30,6 @@ In order for all dependencies to resolve correctly, the following additional Ecl
 * M2E - Maven Integration for Eclipse
 * M2E - PDE Integration
 * XText Complete SDK
-* XCore
 
 You can install these packages using your Eclipse IDE by selecting Help -> Install New Software (Eclipse Repository). 
 

--- a/src/development/building4diac.asciidoc
+++ b/src/development/building4diac.asciidoc
@@ -20,12 +20,19 @@ Run through the following steps to build and execute the 4diac IDE from source:
 
 === [[devEnvironment]]Get the Development Environment
 
+The 4diac IDE requires at least a version 17 Java JRE. Higher version JREs are supported, but may require additional Eclipse IDE configuration (see step 4 of link:#importPlugins[Import plug-ins into workspace]).
+
 Get the latest https://eclipse.org/downloads/eclipse-packages/[Eclipse IDE]. Use [.specificText]#Eclipse Modeling Tools# edition.
 
-In addition you need the XText SDK. 
-You can add within your Eclipse Modeling Tools by selecting Install New Software from the Help Menu.
-There choose the latest Eclipse repository, wait till the package information is loaded, and then search for XText complete SDK.
 
+In order for all dependencies to resolve correctly, the following additional Eclipse packages are required:
+
+* M2E - Maven Integration for Eclipse
+* M2E - PDE Integration
+* XText Complete SDK
+* XCore
+
+You can install these packages using your Eclipse IDE by selecting Help -> Install New Software (Eclipse Repository). 
 
 === [[checkOutRepos]]Check out the 4diac IDE Repository
 
@@ -33,19 +40,27 @@ This section shows how to check out (clone) the 4diac IDE repository.
 You will need https://git-scm.com/downloads[Git] to download it by using the `clone` command from Git to the repository `https://git.eclipse.org/r/4diac/org.eclipse.4diac.ide`. 
 If you're using the terminal, do:
 ----
-$ cd ~ $ git clone https://git.eclipse.org/r/4diac/org.eclipse.4diac.ide
+$ cd ~
+$ git clone https://git.eclipse.org/r/4diac/org.eclipse.4diac.ide
 ----
 The code will be copied to the new created folder
 ~/org.eclipse.4diac.ide.
 
 You can also use the git integrated into Eclipse for this process.
-Please refer to the Eclipse EGit documentation on how to clone a repository
+Please refer to the Eclipse EGit documentation on how to clone a repository.
+
+Once you have cloned the repository make sure that you switch to the `develop` branch. Thhe default branch, `master`, might be out of date and thus incompatible with these setup steps.
+----
+$ cd ~/org.eclipse.4diac.ide/
+$ git checkout develop
+----
 
 === [[importPlugins]]Import Plug-Ins into Workspace
 
 . [.menu4diac]#File → Import → General → Existing Projects into Workspace#
-. Under [.menu4diac]#Select root directory# select the source directory from the file system and mark all projects to be imported.
+. Under [.menu4diac]#Select root directory# select the source directory from the file system and mark all projects to be imported. If the project list only shows one project (org.eclipse.4diac.ide), make sure the checkbox "Search for nested projects" under "Options" is ticked.
 . Wait till Eclipse finished building the project (look at the progress bar at the right bottom corner of the Eclipse main window)
+. If you have a JRE > 17 installed, you need to make sure the compiler compliance level is set to JDK version 17 in order for the build to succeed. Go to Window -> Preferences. Search for "Compiler" and in the "JDK Compliance" section, set "Compiler compliance level" to 17. If this step has not been completed properly the "Problems" view will be populated with "XText" errors.
 . Check problems view for errors. If you get [.specificText]#API Baseline# not set errors you need to perform the following steps:
 .. Open the Eclipse preferences: [.menu4diac]#Window → Preferences#
 .. Enter API in the top left search field. 
@@ -65,14 +80,17 @@ of the preferences window from Error to Ignore
 +
 image:./img/APIbaseline.png[API Baseline]
 
+----
+Note: If you get an error in the "Problems" view stating "There is a possible API baseline mismatch ...", you can safely ignore this message. This message will not prevent the IDE from building successfully.
+----
 
 === [[targetPlatform]]Set Target Platform
 
-. Open the Eclipse preferences within the `org.eclipse.fordiac.ide.product` plugin:
+. Expand the project `org.eclipse.fordiac.ide.product` and open the target configuration `org.eclipse.fordiac.ide.product.target`:
 +
 image:./TargetPlatform.png[Eclipse target platform configuration]
 . Wait until the target platform is resolved or press [.button4diac]#Reload# and wait until it is resolved
-. Press [.button4diac]#Set as Target Platform# within the upper right corner and wait until the workspace is builded.
+. Press [.button4diac]#Set as Active Target Platform# within the upper right corner and wait until the workspace is built.
 
 === [[devMode]]Run in Development Mode
 . To use 4diac IDE directly under this (development) Eclipse you need a type library and templates. Both are part of the 4diac IDE repository and can be found in the `data` directory. 


### PR DESCRIPTION
This is an improvement to the build instructions for the 4diac IDE, removing some inconsistencies for the current version of Eclipse (4.31) and Java versions > 17.

It should again be possible to get a clean build of the 4diac IDE using these instructions only, without requiring any additional undocumented steps.