### PR TITLE
Fixed links to old html files

### DIFF
--- a/src/communication/arrowhead.adoc
+++ b/src/communication/arrowhead.adoc
@@ -42,7 +42,7 @@ The provided library can be used with HTTP using the provided link before, or OP
 == Enabling the Arrowhead Module in 4diac FORTE 
 
 The first thing that's needed is to have a version of 4diac FORTE with the Arrowhead Module enabled. For that, you'll need to compile your own 4diac FORTE. 
-To do that, follow these xref:../installation/install.adoc#ownFORTE[steps] and in CMake set the variable `FORTE_MODULE_Arrowhead` and `FORTE_COM_HTTP` or/and `FORTE_COM_OPC_UA` to TRUE.
+To do that, follow these xref:../installation/index.adoc#ownFORTE[steps] and in CMake set the variable `FORTE_MODULE_Arrowhead` and `FORTE_COM_HTTP` or/and `FORTE_COM_OPC_UA` to TRUE.
 
 After 4diac FORTE compiles, you'll be ready to use the FBs library in 4diac IDE.
 

--- a/src/communication/http.adoc
+++ b/src/communication/http.adoc
@@ -8,7 +8,7 @@ Currently only `GET`, `POST` or `PUT` requests are supported.
 == Configuration
 
 4diac Forte must be compiled from source code for the HTTP module to work. 
-Follow the xref:../installation/install.html#ownFORTE[steps to build your own FBs]. 
+Follow the xref:../installation/index.adoc#ownFORTE[steps to build your own FBs]. 
 In the step 3 where the features to be compiled are selected, select also `FORTE_COM_HTTP`. 
 Then follow the same procedure, compile 4diac FORTE, et voilà, you have HTTP support on your 4diac FORTE.
 

--- a/src/communication/mqttPaho.adoc
+++ b/src/communication/mqttPaho.adoc
@@ -15,7 +15,7 @@ Since you need MQTT Paho, you need to install the libraries in your computer.
 Therefore you need to download the code and compile it. 
 You will need the same tools needed for 4diac FORTE (git, cmake, compilers). 
 The process is based on the normal compilation of 4diac FORTE, but the MQTT feature is enabled.
-xref:../installation/install.html#ownFORTE[Here's] a quick link to 4diac FORTE's compilation. 
+xref:../installation/index.adoc#ownFORTE[Here's] a quick link to 4diac FORTE's compilation. 
 For the installation please follow the next steps:
 
 . Checkout and build MQTT Paho (if you are using Windows, some commands might change):

--- a/src/communication/opcDA.adoc
+++ b/src/communication/opcDA.adoc
@@ -12,7 +12,7 @@ Download the following packages:
 * http://www.boost.org[Boost Lexical Cast]
 * https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=17[Visual Studio Installer 2022]
 
-== Prepare and compile OPC Client Toolkit
+== [[msbuildtools]]Prepare and compile OPC Client Toolkit
 
 . Unzip Boost C++ Libraries
 . Install Visual Studio Build Tools with the components shown in the below.
@@ -44,12 +44,12 @@ cmake:install         //install
 
 == Compile 4diac FORTE with OPC DA Client Support
 
-. Create a MS Visual Studio Code Project of 4diac FORTE with CMake as described in xref:../installation/visualStudioCode.html[Compiling and Debugging 4diac FORTE with MS Visual Studio Code] and add the following variables in `settings.json` which are required for OPC Client support:
+. Create a MS Visual Studio Code Project of 4diac FORTE with CMake as described in xref:../installation/visualStudioCode.adoc[Compiling and Debugging 4diac FORTE with MS Visual Studio Code] and add the following variables in `settings.json` which are required for OPC Client support:
 * `FORTE_COM_OPC` : ON,
 * `FORTE_COM_OPC_LIB_ROOT`: Your path to opc lib root,
 * `FORTE_COM_OPC_BOOST_ROOT`: Your path to boost root,
 . Open the 4diac FORTE Project with MS Visual Studio Code.
-. xref:../installation/visualStudioCode.html[compile or debug] 4diac FORTE
+. xref:../installation/visualStudioCode.adoc[compile or debug] 4diac FORTE
 
 == Create OPC Client
 

--- a/src/communication/opcUA.adoc
+++ b/src/communication/opcUA.adoc
@@ -5,7 +5,7 @@ ifdef::env-github[]
 :imagesdir: img
 endif::[]
 
-This tutorial shows how you can use https://en.wikipedia.org/wiki/OPC_Unified_Architecture[OPC UA] in an IEC 61499 Application using available FBs. You should first complete the xref:../tutorials/use4diacLocally.html[First Steps in Eclipse 4diac Tutorial] to get familiar with the 4diac IDE. 
+This tutorial shows how you can use https://en.wikipedia.org/wiki/OPC_Unified_Architecture[OPC UA] in an IEC 61499 Application using available FBs. You should first complete the xref:../tutorials/use4diacLocally.adoc[First Steps in Eclipse 4diac Tutorial] to get familiar with the 4diac IDE. 
 4diac FORTE uses the http://open62541.org/[open62541] OPC UA stack which is open source and can also be used in commercial projects free of charge.
 
 After version 1.11.0 of 4diac FORTE, the OPC UA module has changed its API, so applications developed before this version won't be compatible. 

--- a/src/communication/simulation.adoc
+++ b/src/communication/simulation.adoc
@@ -22,7 +22,7 @@ With both FMUs in hand, a co-simulation tool can be used to connect the inputs a
 === How to export and FMU in 4diac IDE?
 
 . First, a special 4diac FORTE has to be compiled. 
- Follow the xref:..//installation/install.adoc#ownFORTE[steps to build your own FBs]. 
+ Follow the xref:..//installation/index.adoc#ownFORTE[steps to build your own FBs]. 
  In the step 3 where the features to be compiled are selected, select also `FORTE_ENABLE_FMU`. 
  The `FORTE_FMU_INCLUDE` variable should be set to the path where the headers files from the fmi standard are located. 
  This will generate a dynamic library, whose name will depend on the operative system 4diac FORTE was compiled. 

--- a/src/communication/xqueries.adoc
+++ b/src/communication/xqueries.adoc
@@ -25,7 +25,7 @@ git clone https://github.com/BaseXdb/basex.git
 ----
 
 Then configure CMake to build the 4diac FORTE. 
-If you do not know how to build the 4diac FORTE read the xref:../installation/install.html#ownFORTE[build instructions first]. 
+If you do not know how to build the 4diac FORTE read the xref:../installation/index.adoc#ownFORTE[build instructions first]. 
 Besides the usual configuration activate the Xquery Client in the 4diac FORTE CMake configuration: 
 ----
 FORTE_COM_XqueryClient=ON
@@ -140,7 +140,7 @@ st_xSuccessor().append("' "
 Please consider that your XQuery is dependent on the data structure of your database. 
 In this case it is the structure of an AutomationML file for a xref:./img/xquery/BaSys_PalletSystem_Model.aml[_Pallet System_].
 After you have created your test function block, export it and build your 4diac FORTE with it. 
-Please have a look at the xref:../installation/install.html#ownFORTE[build instructions] if you do not know how to build your own function block.
+Please have a look at the xref:../installation/index.adoc#ownFORTE[build instructions] if you do not know how to build your own function block.
 
 Now you can use your test function block within an application. 
 To send the XQueries to your BaseX database, add a `CLIENT_1` for each query you want to send. 

--- a/src/development/contribute.asciidoc
+++ b/src/development/contribute.asciidoc
@@ -112,9 +112,9 @@ Nevertheless, users without command line experience should stick to Eclipse.
 +
 The first thing to do is to get all the software. 
 For 4diac FORTE download Eclipse for C++ and install it. 
-The installation of the toolchain is described xref:../installation/install.html#ownIDE[here]. 
+The installation of the toolchain is described xref:../installation/index.adoc#ownIDE[here]. 
 If you already have an Eclipse IDE but it's not configured for C++, you don't need to download another Eclipse, but only the C++ plugin. See a tutorial http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.cdt.doc.user%2Fgetting_started%2Fcdt_w_install_cdt.htm[here].
-To install Eclipse IDE for developing 4diac IDE use this xref:../development/building4diac.html#buildFromSource[instruction].
+To install Eclipse IDE for developing 4diac IDE use this xref:../development/building4diac.adoc#buildFromSource[instruction].
 EGit should be installed automatically with your Eclipse, otherwise follow the steps http://www.vogella.com/tutorials/EclipseGit/article.html#eclipseinstallationgit[here] to install it.
 . Configure EGit
 +
@@ -602,7 +602,7 @@ Contributors:
 
 Back to Development index:
 
-xref:./index.html[Development Index]
+xref:./index.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access:
 

--- a/src/development/externalEvent_example.adoc
+++ b/src/development/externalEvent_example.adoc
@@ -22,7 +22,7 @@ Consider that this is just an example that does not follow the IEC 61499 standar
 === The Interface
 
 T Flip-Flop as SIFB with integrated Timer.
-xref:../tutorials/createOwnTypes.adoc#exportTypes[Export the interface to 4diac FORTE] (`*.h` and `*.cpp` files) and xref:../installation/install.adoc#externalModules[include them to your build].
+xref:../tutorials/createOwnTypes.adoc#exportTypes[Export the interface to 4diac FORTE] (`*.h` and `*.cpp` files) and xref:../installation/index.adoc#externalModules[include them to your build].
 
 image:flipFlop_integratedTimer.jpg[Interface of the T Flip-Flop as SIFB with integrated Timer]
 

--- a/src/development/forte_communicationArchitecture.adoc
+++ b/src/development/forte_communicationArchitecture.adoc
@@ -309,7 +309,7 @@ We only show a few of the methods here, for more information check source code.
 
 Go back to Development index:
 
-xref:./index.html[Development Index]
+xref:./index.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 

--- a/src/development/forte_monitoring.adoc
+++ b/src/development/forte_monitoring.adoc
@@ -61,7 +61,7 @@ Currently the following monitoring commands are supported:
 
 Go back to Development index:
 
-link:./index.html[Development Index]
+link:./index.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 

--- a/src/examples/bbbTrafficControl.adoc
+++ b/src/examples/bbbTrafficControl.adoc
@@ -72,8 +72,8 @@ Next go to the folder `bin/posix` inside your 4diac FORTE folder, and there exe
 the BBB is not as fast as a normal computer. 
 That's why a cross-compiler might be a good idea. When the compilation is finished, you will find the 4diac FORTE executable in the folder `bin/posix/src` inside your 4diac FORTE folder.
 
-If you have trouble with building 4diac FORTE, you can follow the steps as the xref:../installation/raspi.html#building[Raspberry Pi].
-If some softwares are missing in the BBB, find more information in the xref:../installation/raspi.html#preparation[preparation] part of the Raspberry Pi.
+If you have trouble with building 4diac FORTE, you can follow the steps as the xref:../installation/raspi.adoc#building[Raspberry Pi].
+If some softwares are missing in the BBB, find more information in the xref:../installation/raspi.adoc#preparation[preparation] part of the Raspberry Pi.
 
 == Configure the system in 4diac IDE
 
@@ -130,7 +130,7 @@ After that everything should work fine.
 
 Go back to Examples index:
 
-xref:./index.html[Examples Index]
+xref:./index.adoc[Examples Index]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access

--- a/src/examples/index.adoc
+++ b/src/examples/index.adoc
@@ -9,7 +9,7 @@ If you want to contribute, you're welcome to do it by contributing the https://g
 
 For the following examples, you don't need any special hardware:
 
-* xref:./xplus3.html[X+3]: This example uses 2 devices, 1 running 4diac FORTE and the other running FBRT. 
+* xref:./xplus3.adoc[X+3]: This example uses 2 devices, 1 running 4diac FORTE and the other running FBRT. 
   It has a really simple logic that allows the user to interact by inputing a number that's sent to 4diac FORTE, which add 3 to the input and returns the result which is shown back to the user.
 
 

--- a/src/examples/pidMotor.adoc
+++ b/src/examples/pidMotor.adoc
@@ -266,7 +266,7 @@ NOTE: In Windows machines, the used Multicast address is not always detected and
 application in the PC. 
 This happens often if the PC is connected to the EV3 through an ad-hoc connection. 
 To overcome this, try adding the address route with gateway to your own machine in the as presented in the Troubleshooting part at the bottom of the
-link:./bbbTrafficControl.html#troubleshooting[Traffic Control with BBB example]
+link:./bbbTrafficControl.adoc#troubleshooting[Traffic Control with BBB example]
 
 == Tuning the PID
 
@@ -296,7 +296,7 @@ image:pidMotor/PIDTuned.png[Final tun of the PID controller]
 
 Go back to Examples index:
 
-link:./examplesIndex.html[Examples Index]
+link:./index.adoc[Examples Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 

--- a/src/examples/xplus3.adoc
+++ b/src/examples/xplus3.adoc
@@ -148,7 +148,7 @@ To download and test your IEC 61499 [.element61499]#Application#:
 
 Go back to Examples index:
 
-xref:./index.html[Examples Index]
+xref:./index.adoc[Examples Index]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access

--- a/src/installation/eclipse.adoc
+++ b/src/installation/eclipse.adoc
@@ -20,7 +20,7 @@ image:eclipseInstallNewSoftware.png[Install new software in Eclipse]
 
 == Compile 4diac FORTE with Eclipse
 
-The build process is described in the xref:./install.adoc#FORTEsteps[installation tutorial]. 
+The build process is described in the xref:./index.adoc#FORTEsteps[installation tutorial]. 
 Perform the steps described there but consider the following adaption:
 
 When generating a project with CMake you must choose the correct project type. 

--- a/src/installation/index.adoc
+++ b/src/installation/index.adoc
@@ -15,7 +15,7 @@ If you only want to use available Function Blocks, you are ready to go.
 === [[ownIDE]]Building Your own 4diac IDE From Source
 
 Running 4diac IDE from source has the advantage that you can easily keep up with the developments performed in the Git repository. 
-If you want to run 4diac IDE from source, follow the xref:../development/building4diac.html#buildFromSource[installation steps]. 
+If you want to run 4diac IDE from source, follow the xref:../development/building4diac.adoc#buildFromSource[installation steps]. 
 This option aims mainly at 4diac IDE developers or people who wish to extend 4diac IDE.
 
 == [[FORTE]]4diac FORTE
@@ -23,7 +23,7 @@ This option aims mainly at 4diac IDE developers or people who wish to extend 4d
 4diac FORTE can be used in two ways: For conducting first experiments with Eclipse 4diac, you can use the pre-built version of 4diac FORTE which is available as https://eclipse.dev/4diac/en_dow.php[download] for Linux and Windows. 
 It can be used for applications unless you need own Function Blocks. 
 The step by step tutorial will direct you to making a simple application with 4diac IDE and pre-built 4diac FORTE. 
-If you want to start using 4diac IDE right away, you can skip the rest of the page and go directly to the xref:../tutorials/overview.html[step by step tutorial] or the xref:../index.adoc[Start Here-page].
+If you want to start using 4diac IDE right away, you can skip the rest of the page and go directly to the xref:../tutorials/overview.adoc[step by step tutorial] or the xref:../index.adoc[Start Here-page].
 
 If you want to develop your own Function Blocks or to run 4diac FORTE on control devices, you have to download and set up 4diac FORTE for the specific platform you are using as shown in the next sections.
 
@@ -43,7 +43,7 @@ You'll need to perform several steps:
 . link:#generateFilesForCompiling[Build a project with CMake]
 . link:#FORTEcompile[Compile] the project
 . link:#externalModules[Add external modules]: your own FBs
-. (optional) Install a development environment for C++ such as xref:./eclipse.html[Eclipse] or xref:./visualStudio.html[MS Visual Studio]
+. (optional) Install a development environment for C++ such as xref:./eclipse.adoc[Eclipse] or xref:./visualStudio.adoc[MS Visual Studio]
 
 ==== [[FORTEWindows]]C++ Compiler for Windows
 
@@ -173,7 +173,7 @@ link:#FORTEsteps[back]
 
 Let's see how to add your own Function Blocks to 4diac FORTE. 
 When you create and export your own types, you need to add them to your compilation. 
-The export is described in the xref:../tutorials/createOwnTypes.html#exportTypes[tutorial step 4]. 
+The export is described in the xref:../tutorials/createOwnTypes.adoc#exportTypes[tutorial step 4]. 
 As an example, we show how to add the four FBs BasicTest, CompositeTest, and ServiceTest, SimpleTest from this tutorial. 
 The name of the module will be EXAMPLE_TEST. 
 Follow the instructions:

--- a/src/installation/legoMindstormEv3.adoc
+++ b/src/installation/legoMindstormEv3.adoc
@@ -3,7 +3,7 @@
 
 
 This page is for compiling 4diac FORTE for the Lego Mindstorm EV3. 
-For information about the parameters to be used, go to the link:../../html/parameters/parameters.html#ev3[Parameters] page.
+For information about the parameters to be used, go to the link:../io_config/EV3.adoc[EV3 IO configuration] page.
 
 == [[ev3_introduction]]About the Lego Mindstorm EV3 and ev3dev
 
@@ -112,7 +112,7 @@ Next, you should go into the bin/ev3dev folder and simply execute "make" to star
 If you want to compile directly in your EV3, then start at step 4 and perform everything with the command prompt of your EV3 (to get the command prompt inside of your EV3, connect to it with PuTTY).
 
 Remember, when you create your own FBs, you should add these to the 4diac FORTE folder, adjust the CMakefiles.txt and compile again. 
-In the link:./install.adoc#ownFORTE[example] section, it is explained how to do this.
+In the link:./index.adoc#ownFORTE[example] section, it is explained how to do this.
 
 == Troubleshooting
 

--- a/src/installation/minGW.adoc
+++ b/src/installation/minGW.adoc
@@ -50,7 +50,7 @@ This is because this file is the one you will use to compile 4diac FORTE, and "
 
 == Next steps
 
-Now that you successfully installed a compiler, you can continue with the next step of the xref:./install.adoc#FORTEsteps[installation tutorial]. 
+Now that you successfully installed a compiler, you can continue with the next step of the xref:./index.adoc#FORTEsteps[installation tutorial]. 
 All information in the installation tutorial is based on a setup with MinGW-w64. 
 For users with previous experience in building a 4diac FORTE, the details are listed:
 

--- a/src/installation/pikeos_posix.adoc
+++ b/src/installation/pikeos_posix.adoc
@@ -181,7 +181,7 @@ Assign "POSIX Process (2)" to this channel.
 
 Go to `qemu-... / ... Ethernet User Level Driver` and set "Enable Multicast Communication" to true for `...-net-device`, `...-net-vchan0` and `...-net-vchan1`.
 
-Now you are able to test the partitions by starting QEMU and perform the xref:../tutorials/overview.html[4DIAC-step-by-step tutorial].
+Now you are able to test the partitions by starting QEMU and perform the xref:../tutorials/overview.adoc[4DIAC-step-by-step tutorial].
 
 On using user mode network you have to start QEMU by selecting "Start QEMU with custom commandline" and defining portforwarding:
 ----

--- a/src/installation/raspi.adoc
+++ b/src/installation/raspi.adoc
@@ -9,7 +9,7 @@ endif::[]
 == Introduction
 
 This guide is for compiling FORTE for the Raspberry Pi. 
-For information about the parameters to be used, go to link:../../html/parameters/parameters.html#sysfs[Parameters].
+For information about the parameters to be used, go to xref:../io_config/SysFs.adoc[Parameters].
 
 https://www.raspberrypi.org/[Raspberry Pi] (RPI) is one of the most famous low-cost embedded systems. 
 In its third generation, the Raspberry Pi 3 was launched in February 2016. 

--- a/src/installation/visualStudio.adoc
+++ b/src/installation/visualStudio.adoc
@@ -7,7 +7,7 @@ endif::[]
 
 
 The following describes how to compile 4diac FORTE with win32-architecture using Visual Studio. 
-In the installation tutorial xref:./install.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
+In the installation tutorial xref:./index.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
 Additionally, other tools are described there.
 
 IMPORTANT: If you are using a Visual Studio version older then 2010 you might need to extend it with a stdint.h file. 
@@ -15,7 +15,7 @@ See for example http://stackoverflow.com/questions/12970293/why-microsoft-visual
 
 == Building a MS Visual Studio Project for 4diac FORTEwith CMake
 
-In the xref:./install.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
+In the xref:./index.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
 To use Visual Studio, you need to however select the tool MS Visual Studio. 
 The correct architecture is Win32.
 
@@ -25,7 +25,7 @@ The correct architecture is Win32.
 . Press the [.button4diac]#Configure# button and choose the version of Visual Studio that is used and native default compilers. 
   Press the [.button4diac]#Finish# button afterwards.
 . For the option [.specificText]#FORTE_ARCHITECTURE#, select Win32. 
-  Other modules and configurations options can be set following the tutorial step link:./install.adoc#generateFilesForCompiling[Build a project with CMake].
+  Other modules and configurations options can be set following the tutorial step link:./index.adoc#generateFilesForCompiling[Build a project with CMake].
 . Press the [.button4diac]#Configure# button, check red rows and repeat this until no row appears red. Afterwards, press the button [.button4diac]#Generate#.
 
 == Compile 4diac FORTEwith Visual Studio

--- a/src/installation/visualStudioCode.adoc
+++ b/src/installation/visualStudioCode.adoc
@@ -7,14 +7,14 @@ endif::[]
 
 
 The following describes how to compile 4diac FORTE with win32-architecture using Visual Studio Code. 
-In the installation tutorial xref:./install.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
+In the installation tutorial xref:./index.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
 Additionally, visual studio code is described there.
 
 == Building a MS Visual Studio Code Project for 4diac FORTE with CMake
 
-In the xref:./install.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
+In the xref:./index.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
 To use Visual Studio Code with CMake, you need to specify the options (All the options are shown in CMake-GUI when you choose source
-folder FORTE_FOLDER_ROOT, refer to xref:./install.adoc#generateFilesForCompiling[Build a project with CMake].) for CMake in settings.json for the project in Visual Studio Code.
+folder FORTE_FOLDER_ROOT, refer to xref:./index.adoc#generateFilesForCompiling[Build a project with CMake].) for CMake in settings.json for the project in Visual Studio Code.
 The correct architecture is Win32. 
 Below is an example of settings.json for forte with OPC DA compiled.
 
@@ -39,8 +39,8 @@ Below is an example of settings.json for forte with OPC DA compiled.
 == Compile and debug 4diac FORTE with Visual Studio Code
 
 . Install compiler. 
-  For example, msbuild tools if you want to compile OPC DA, install the components according to xref:../communication/opc.adoc#msbuildtools[ms buildtools]. 
-  Or if you prefer mingw-w64, follow xref:./minGW.html[mingw-w64]. 
+  For example, msbuild tools if you want to compile OPC DA, install the components according to xref:../communication/opcDA.adoc#msbuildtools[ms buildtools]. 
+  Or if you prefer mingw-w64, follow xref:./minGW.adoc[mingw-w64]. 
 . Install "CMake tools" plugin in visual studio code.
 . Open command palette(ctrl + shift + p), compile or debug in below command:
 +

--- a/src/intro/4diacFramework.adoc
+++ b/src/intro/4diacFramework.adoc
@@ -53,7 +53,7 @@ As described, you can create FBs in 4diac IDE.
 At this point, however, the run-time environment doesn't know that the FB exists nor how to execute it. 
 Within 4diac IDE, you therefore have the possibility to export your created FB into 4diac FORTE code (i.e., C++ files). 
 You then need to add your exported code to the source code of 4diac FORTE and compile all as explained in the
-xref:../installation/install.adoc#FORTE[Compile 4diac FORTE] section of the installation documentation. 
+xref:../installation/index.adoc#FORTE[Compile 4diac FORTE] section of the installation documentation. 
 This is possible only for Basic and Composite Function Blocks (BFB and CFB), since both definitions are in the standard. 
 However, for Service Interface Function Blocks (SIFBs) only the interface is defined. 
 The internal implementation of an SIFB has to be coded manually in C++, the language 4diac FORTE is written in.
@@ -69,7 +69,7 @@ Currently, the most commonly used protocols are MQTT or OPC UA.
 
 * Now that you have a better understanding of the IEC 61499 standard, and know about the tools around Eclipse 4diac, is time to start using them.
 Take a look at the following page: +
-xref:../installation/install.adoc[Installation]
+xref:../installation/index.adoc[Installation]
 * If you want to go back to the Where to Start page, we leave you here a fast access: +
 xref:../index.adoc[Where to Start]
 

--- a/src/tutorials/distribute4diac.adoc
+++ b/src/tutorials/distribute4diac.adoc
@@ -66,7 +66,7 @@ There you can see 2 incomplete FBs at the E_SR FB or E_PERMIT.
 They symbolize the broken connections between the two devices. 
 Currently they have no opportunity to communicate with each other. 
 We fix it by adding special Communications FBs. 
-You can find more information about broken connections xref:../intro/iec61499.html#brokenConnection[here on our Homepage].
+You can find more information about broken connections xref:../intro/iec61499.adoc#brokenConnection[here on our Homepage].
 
 image:Step2/incompleteFBs.png[incomplete FBs show die broken connection between two devices]
 

--- a/src/tutorials/dynamicTypeLoader.adoc
+++ b/src/tutorials/dynamicTypeLoader.adoc
@@ -31,7 +31,7 @@ Instead of directly compiled into 4diac FORTE, the FBs are downloaded as LUA Co
 Before we can use the Dynamic Type Loader, we have to compile a new 4diac FORTE with the Lua JIT (Just-In-Time Compiler). 
 Therefore we are going to need a C-compiler. 
 If you have done the tutorial, on how to create your own 4diac FORTE, everything you need should already be installed. 
-Otherwise, follow the steps xref:../installation/install.adoc[here].
+Otherwise, follow the steps xref:../installation/index.adoc[here].
 
 We recommend using the minGW compiler.
 
@@ -63,7 +63,7 @@ Then create an folder where we are going to build our 4diac FORTE in.
 Open CMake and set the source folder, to the folder where your 4diac FORTE source files are in. 
 Then set the build folder, to folder where you want to build 4diac FORTE in.
 
-Before configuring the Lua options, please enable all options, shown in this xref:../installation/install.html#generateFilesForCompiling[tutorial].
+Before configuring the Lua options, please enable all options, shown in this xref:../installation/index.adoc#generateFilesForCompiling[tutorial].
 Before pressing generate, we have to configure all Lua options.
 
 . Set `FORTE_USE_LUATYPES` to `LUAJIT` and press configure

--- a/src/tutorials/use4diacLocally.adoc
+++ b/src/tutorials/use4diacLocally.adoc
@@ -217,7 +217,7 @@ Before we test our application, let's briefly summarize the elements we've worke
 In this step, the Blink application will be deployed to 4diac FORTE running locally on your computer.
 
 . You have to select a 4diac FORTE. +
-You can either build your own 4diac FORTE as xref:..//installation/install.html#ownFORTE[shown here] or you can download the 4diac FORTE image that is provided for you for this tutorial on https://eclipse.dev/4diac/en_dow.php[our Homepage]. 
+You can either build your own 4diac FORTE as xref:../installation/index.adoc#ownFORTE[shown here] or you can download the 4diac FORTE image that is provided for you for this tutorial on https://eclipse.dev/4diac/en_dow.php[our Homepage]. 
 You can save the .exe wherever you like, we have chosen `F:\4diac\4diac IDE\`. 
 Go to [.menu4diac]#Windows → Preferences → 4diac IDE → FORTE Preferences#, and in [.addressDoc]#FORTE Location# look for the 4diac FORTE executable and then click _Apply and Close_. +
 image:Step1/selectForte.png[select your 4diac FORTE,width=600]

--- a/src/tutorials/use4diacRemotely.adoc
+++ b/src/tutorials/use4diacRemotely.adoc
@@ -31,7 +31,7 @@ image:Step3/remoteArchitecture.png[architecture for the current step]
   The cheap options are Raspberry Pi, BeagleBoneBlack or another small board that runs Linux. 
   Another option would be to use another computer in your network.
 . Compile 4diac FORTE for your PLC or other Hardware. 
-  Check link:..//installation/install.adoc#FORTEWindowsUnix[here] for more information.
+  Check link:..//installation/index.adoc#FORTEWindowsUnix[here] for more information.
 . Go to the System Configuration of the _BlinkTest_ and change the address from localhost to the IP address of your device. 
   This is the easiest way to interact with an external device. +
   However, certain devices require a special device type. 
@@ -100,9 +100,9 @@ After that everything should work fine.
 == Where to go from here?
 
 * In the next step you will see how to create your own Function Blocks: +
-xref:./createOwnTypes.html[Step 4 - Create Your own Function Block Types]
+xref:./createOwnTypes.adoc[Step 4 - Create Your own Function Block Types]
 * If you want to go back to the distributed application running completely locally, here's a link: +
-xref:./distribute4diac.html[Step 2 - Distribute 4diac Applications]
+xref:./distribute4diac.adoc[Step 2 - Distribute 4diac Applications]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../index.adoc[Where to Start]
 


### PR DESCRIPTION
In order that all links work correctly also on github the ending was changed from html to adoc. Also links to install.adoc where changed to the new file index.adoc.