### PR TITLE
Fixed typo in swtBotTestsDocumentation.asciidoc

### DIFF
--- a/src/development/swtBotTestsDocumentation.asciidoc
+++ b/src/development/swtBotTestsDocumentation.asciidoc
@@ -2,7 +2,7 @@
 :lang: en
 :imagesdir: ./src/development/img/SWTBot
 ifdef::env-github[]
-:imagesdir: img/SWTBOT
+:imagesdir: img/SWTBot
 endif::[]
 
 * link:#ImprovementThroughAutomatedTesting[Eclipse 4diac IDE User Interface Quality Improvement Through Automated Testing]


### PR DESCRIPTION
The images of the SWTBot Documentation were not displayed because of a typo in the imagesdir.  img/SWTBOT was corrected to img/SWTBot .