### PR TITLE
Rework Documentation to be better integrateable in Hugo-based Web-Page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
 						 	<sourceDirectory>src</sourceDirectory>
                             <backend>html5</backend>
                             <preserveDirectories>true</preserveDirectories>
+                            <attributes>
+                                <skip-front-matter>true</skip-front-matter>
+                            </attributes>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/_index.adoc
+++ b/src/_index.adoc
@@ -1,0 +1,8 @@
+---
+# this file is for getting a better experience on Eclipse 4diac's webpage
+
+title: "Documentation"
+layout: "single"
+---
+
+include::doc_overview.adoc[]

--- a/src/communication/arrowhead.adoc
+++ b/src/communication/arrowhead.adoc
@@ -1,10 +1,11 @@
-= [[topOfPage]]How to use 4diac's Arrowhead library
-:lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
-:imagesdir: img
-endif::[]
+---
+title: "How to use Eclipse 4diac's Arrowhead Library"
+url: doc/communication/arrowhead.html
+---
 
+= [[topOfPage]]How to use Eclipse 4diac's Arrowhead Library
+:lang: en
+:imagesdir: img
 
 == [[intro]]Introduction
 
@@ -42,7 +43,7 @@ The provided library can be used with HTTP using the provided link before, or OP
 == Enabling the Arrowhead Module in 4diac FORTE 
 
 The first thing that's needed is to have a version of 4diac FORTE with the Arrowhead Module enabled. For that, you'll need to compile your own 4diac FORTE. 
-To do that, follow these xref:../installation/index.adoc#ownFORTE[steps] and in CMake set the variable `FORTE_MODULE_Arrowhead` and `FORTE_COM_HTTP` or/and `FORTE_COM_OPC_UA` to TRUE.
+To do that, follow these xref:../installation/installation.adoc#ownFORTE[steps] and in CMake set the variable `FORTE_MODULE_Arrowhead` and `FORTE_COM_HTTP` or/and `FORTE_COM_OPC_UA` to TRUE.
 
 After 4diac FORTE compiles, you'll be ready to use the FBs library in 4diac IDE.
 
@@ -175,8 +176,8 @@ The FBs are not directly to be found in 4diac IDE, but you'll find them in the 
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/communication.adoc
+++ b/src/communication/communication.adoc
@@ -1,5 +1,9 @@
-[[topOfPage]]
-= Eclipse 4diac Supported Communication Protocols
+---
+title: "Supported Communication Protocols"
+url: doc/communication/communication.html
+---
+
+= [[topOfPage]] Eclipse 4diac Supported Communication Protocols
 
 This page is intended to serve as index for communication protocols that
 are supported by 4diac FORTE.
@@ -17,3 +21,6 @@ are supported by 4diac FORTE.
 * xref:openPOWERLINK.adoc[openPOWERLINK]
 * xref:arrowhead.adoc[Arrowhead]
 * xref:xqueries.adoc[Access BaseX Database with XQueries]
+
+* If you want to go back to the Start Here page, we leave you here a fast access +
+xref:../doc_overview.adoc[Start Here page]

--- a/src/communication/fbdkip.adoc
+++ b/src/communication/fbdkip.adoc
@@ -1,9 +1,11 @@
+---
+title: "FBDK/IP"
+url: doc/communication/fbdkip.html
+---
+
 = [[topOfPage]]FBDK/IP
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This section will show you how to make applications communicate using the default FBDK/ip protocol as defined in the http://holobloc.com/doc/ita/index.htm[IEC 61499 Compliance Profile for Feasibility Demonstrations]. 
 Because we are going to use the default protocol, we don't have to put it as a parameter in the beginning of the ID input of the Communication Function Blocks. 
@@ -101,8 +103,8 @@ image:clientserver.png[Client/Server pair]
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access + 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/http.adoc
+++ b/src/communication/http.adoc
@@ -1,3 +1,8 @@
+---
+title: "HTTP"
+url: doc/communication/HTTP.html
+---
+
 = [[topOfPage]]HTTP
 
 This section shows how to make applications communicate using the HTTP protocol. 
@@ -8,7 +13,7 @@ Currently only `GET`, `POST` or `PUT` requests are supported.
 == Configuration
 
 4diac Forte must be compiled from source code for the HTTP module to work. 
-Follow the xref:../installation/index.adoc#ownFORTE[steps to build your own FBs]. 
+Follow the xref:../installation/installation.adoc#ownFORTE[steps to build your own FBs]. 
 In the step 3 where the features to be compiled are selected, select also `FORTE_COM_HTTP`. 
 Then follow the same procedure, compile 4diac FORTE, et voilà, you have HTTP support on your 4diac FORTE.
 
@@ -59,8 +64,8 @@ The values are stored in the RDs in the order they arrived and treated as `STRIN
 == Where to go from here?
 
  * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/modbus.adoc
+++ b/src/communication/modbus.adoc
@@ -1,9 +1,11 @@
+---
+title: "Modbus"
+url: doc/communication/modbus.html
+---
+
 = [[topOfPage]]Modbus
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == Installation Instructions
 
@@ -127,8 +129,8 @@ image:modbus/modbus_8Q.png[modbus with 8Q set]
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/mqttPaho.adoc
+++ b/src/communication/mqttPaho.adoc
@@ -1,9 +1,11 @@
+---
+title: "MQTT with Eclipse Paho"
+url: doc/communication/mqttPaho.html
+---
+
 = [[topOfPage]]MQTT with Eclipse Paho
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This section will show you how to make applications communicate using http://www.eclipse.org/paho/[MQTT Paho]. 
 4diac FORTE uses a layered communication architecture. 
@@ -15,7 +17,7 @@ Since you need MQTT Paho, you need to install the libraries in your computer.
 Therefore you need to download the code and compile it. 
 You will need the same tools needed for 4diac FORTE (git, cmake, compilers). 
 The process is based on the normal compilation of 4diac FORTE, but the MQTT feature is enabled.
-xref:../installation/index.adoc#ownFORTE[Here's] a quick link to 4diac FORTE's compilation. 
+xref:../installation/installation.adoc#ownFORTE[Here's] a quick link to 4diac FORTE's compilation. 
 For the installation please follow the next steps:
 
 . Checkout and build MQTT Paho (if you are using Windows, some commands might change):
@@ -60,8 +62,8 @@ The raw-layer is just accepting strings and sends the raw string content.
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/opcDA.adoc
+++ b/src/communication/opcDA.adoc
@@ -1,9 +1,11 @@
+---
+title: "OPC DA"
+url: doc/communication/opcDA.html
+---
+
 = [[topOfPage]]OPC DA
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This section will show you how to create an OPC DA Client with 4diac IDE and how to use it with 4diac FORTE. 
 Download the following packages: 
@@ -100,9 +102,9 @@ image:opc_festoOPCserverIO.png[Festo OPC Server IO]
 == Where to go from here?
 
  * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/opcUA.adoc
+++ b/src/communication/opcUA.adoc
@@ -1,9 +1,11 @@
+---
+title: "OPC UA with IEC 61499 Tutorial"
+url: doc/communication/opcUA.html
+---
+
 = [[topOfPage]]OPC UA with IEC 61499 Tutorial
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This tutorial shows how you can use https://en.wikipedia.org/wiki/OPC_Unified_Architecture[OPC UA] in an IEC 61499 Application using available FBs. You should first complete the xref:../tutorials/use4diacLocally.adoc[First Steps in Eclipse 4diac Tutorial] to get familiar with the 4diac IDE. 
 4diac FORTE uses the http://open62541.org/[open62541] OPC UA stack which is open source and can also be used in commercial projects free of charge.
@@ -491,8 +493,8 @@ You're done. Now, when your application tries to connect to `opc.tcp://192.168.1
 == Where to go from here?
 
  * Go back to Protocols index: +
-xref:./index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/openPOWERLINK.adoc
+++ b/src/communication/openPOWERLINK.adoc
@@ -1,3 +1,8 @@
+---
+title: "openPOWERLINK"
+url: doc/communication/openPOWERLINK.html
+---
+
 = [[topOfPage]]openPOWERLINK
 
 http://openpowerlink.sourceforge.net/web/[openPOWERLINK] is an Open Source Industrial Ethernet stack implementing the https://en.wikipedia.org/wiki/Ethernet_Powerlink[Ethernet POWERLINK] protocol.
@@ -32,8 +37,8 @@ The opwenPOWERLINK folder is part of 4diac's type library.
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/simulation.adoc
+++ b/src/communication/simulation.adoc
@@ -1,9 +1,11 @@
+---
+title: "Communicating with Simulation Tools"
+url: doc/communication/simulation.html
+---
+
 = [[topOfPage]]Communicating with Simulation Tools
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == FMI
 
@@ -22,7 +24,7 @@ With both FMUs in hand, a co-simulation tool can be used to connect the inputs a
 === How to export and FMU in 4diac IDE?
 
 . First, a special 4diac FORTE has to be compiled. 
- Follow the xref:..//installation/index.adoc#ownFORTE[steps to build your own FBs]. 
+ Follow the xref:../installation/installation.adoc#ownFORTE[steps to build your own FBs]. 
  In the step 3 where the features to be compiled are selected, select also `FORTE_ENABLE_FMU`. 
  The `FORTE_FMU_INCLUDE` variable should be set to the path where the headers files from the fmi standard are located. 
  This will generate a dynamic library, whose name will depend on the operative system 4diac FORTE was compiled. 
@@ -100,8 +102,8 @@ For detailed documentation as well as the library code, please have a look at th
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access + 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/tsn.adoc
+++ b/src/communication/tsn.adoc
@@ -1,9 +1,11 @@
+---
+title: "How to use Eclipse 4diac's Time Sensitive Networking Communication Interface"
+url: doc/communication/tsn.html
+---
+
 = [[topOfPage]]How to use Eclipse 4diac's Time Sensitive Networking Communication Interface
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == [[intro]]Introduction
 
@@ -84,9 +86,9 @@ $ sudo ifconfig eth0.3 netmask "your_favorite_netmask"
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/communication/xqueries.adoc
+++ b/src/communication/xqueries.adoc
@@ -1,9 +1,11 @@
+---
+title: "Access BaseX Database with XQueries"
+url: doc/communication/xqueries.html
+---
+
 = [[topOfPage]]Access BaseX Database with XQueries
 :lang: en
-:imagesdir: ./src/communication/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This section will show you how to make applications communicate with a http://basex.org/[BaseX] database through XQueries. 
 This allows a component, to initialize itself by accessing its asset administration shell, in terms of an XML database. 
@@ -25,7 +27,7 @@ git clone https://github.com/BaseXdb/basex.git
 ----
 
 Then configure CMake to build the 4diac FORTE. 
-If you do not know how to build the 4diac FORTE read the xref:../installation/index.adoc#ownFORTE[build instructions first]. 
+If you do not know how to build the 4diac FORTE read the xref:../installation/installation.adoc#ownFORTE[build instructions first]. 
 Besides the usual configuration activate the Xquery Client in the 4diac FORTE CMake configuration: 
 ----
 FORTE_COM_XqueryClient=ON
@@ -140,7 +142,7 @@ st_xSuccessor().append("' "
 Please consider that your XQuery is dependent on the data structure of your database. 
 In this case it is the structure of an AutomationML file for a xref:./img/xquery/BaSys_PalletSystem_Model.aml[_Pallet System_].
 After you have created your test function block, export it and build your 4diac FORTE with it. 
-Please have a look at the xref:../installation/index.adoc#ownFORTE[build instructions] if you do not know how to build your own function block.
+Please have a look at the xref:../installation/installation.adoc#ownFORTE[build instructions] if you do not know how to build your own function block.
 
 Now you can use your test function block within an application. 
 To send the XQueries to your BaseX database, add a `CLIENT_1` for each query you want to send. 
@@ -175,9 +177,9 @@ If you monitor your application you should get the results from the XQuery reque
 == Where to go from here?
 
 * Go back to Protocols index: +
-xref:index.adoc[Communication Index]
+xref:./communication.adoc[Communication Index]
 
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/building4diac.adoc
+++ b/src/development/building4diac.adoc
@@ -1,9 +1,11 @@
+---
+title: "Building and Running 4diac IDE"
+url: doc/development/building4diac.html
+---
+
 = [[topOfPage]]Building and Running 4diac IDE
 :lang: en
-:imagesdir: ./src/development/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 You have 2 options for building and running 4diac IDE:
 
@@ -143,9 +145,9 @@ Alternatively you can run `.mvn .install`  on the command line in the root folde
 
 == Where to go from here?
 
-Go back to xref:./index.adoc[Development Index]
+Go back to xref:./development.adoc[Development Index]
 
-Go back to xref:../index.adoc[Eclipse 4diac Documentation page]
+Go back to xref:../doc_overview.adoc[Eclipse 4diac Documentation page]
  
 Or link:#topOfPage[Go to top]
 

--- a/src/development/contribute.asciidoc
+++ b/src/development/contribute.asciidoc
@@ -1,9 +1,11 @@
-= [[topOfPage]]Contributing to 4diac IDE or 4diac FORTE
+---
+title: "Contributing to Eclipse 4diac"
+url: doc/development/contribute.html
+---
+
+= [[topOfPage]]Contributing to Eclipse 4diac
 :lang: en
-:imagesdir: ./src/development/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 The projects 4diac IDE and 4diac FORTE are stored as a Git repository in the Eclipse platform. 
@@ -109,7 +111,7 @@ Nevertheless, users without command line experience should stick to Eclipse.
 +
 The first thing to do is to get all the software. 
 For 4diac FORTE download Eclipse for C++ and install it. 
-The installation of the toolchain is described xref:../installation/index.adoc#ownIDE[here]. 
+The installation of the toolchain is described xref:../installation/installation.adoc#ownIDE[here]. 
 If you already have an Eclipse IDE but it's not configured for C++, you don't need to download another Eclipse, but only the C++ plugin. See a tutorial http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.cdt.doc.user%2Fgetting_started%2Fcdt_w_install_cdt.htm[here].
 To install Eclipse IDE for developing 4diac IDE use this xref:../development/building4diac.adoc#buildFromSource[instruction].
 EGit should be installed automatically with your Eclipse, otherwise follow the steps http://www.vogella.com/tutorials/EclipseGit/article.html#eclipseinstallationgit[here] to install it.
@@ -557,10 +559,10 @@ Contributors:
 
 Back to Development index:
 
-xref:./index.adoc[Development Index]
+xref:./development.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access:
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/development.adoc
+++ b/src/development/development.adoc
@@ -1,3 +1,8 @@
+---
+title: "Development of 4diac IDE or 4diac FORTE"
+url: doc/development/development.html
+---
+
 = [[topOfPage]]Development of 4diac IDE or 4diac FORTE
 :lang: en
 
@@ -15,6 +20,6 @@ This page is intended to give an overview of the topics you can find in the docu
 * Contributing
 ** xref:./contribute.adoc[Contribute to 4diac IDE or 4diac FORTE]
 
-Go to xref:../index.adoc[Start Here page]
+Go to xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/externalEvent_example.adoc
+++ b/src/development/externalEvent_example.adoc
@@ -1,9 +1,11 @@
+---
+title: "External Event SIFB"
+url: doc/development/externalEvent_example.html
+---
+
 = [[topOfPage]]External Event SIFB
 :lang: en
-:imagesdir: ./src/development/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 External Events are events in 4diac FORTE, which are hidden and can not be seen in 4diac IDE. 
@@ -22,7 +24,7 @@ Consider that this is just an example that does not follow the IEC 61499 standar
 === The Interface
 
 T Flip-Flop as SIFB with integrated Timer.
-xref:../tutorials/createOwnTypes.adoc#exportTypes[Export the interface to 4diac FORTE] (`*.h` and `*.cpp` files) and xref:../installation/index.adoc#externalModules[include them to your build].
+xref:../tutorials/createOwnTypes.adoc#exportTypes[Export the interface to 4diac FORTE] (`*.h` and `*.cpp` files) and xref:../installation/installation.adoc#externalModules[include them to your build].
 
 image:flipFlop_integratedTimer.jpg[Interface of the T Flip-Flop as SIFB with integrated Timer]
 
@@ -117,10 +119,10 @@ if(sm_poDeviceExecution->extEvHandlerIsAllowed(m_nExtEvHandID)) {
 
 Go back to Development index:
 
-xref:./index.adoc[Development Index]
+xref:./development.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/forte_codequality.adoc
+++ b/src/development/forte_codequality.adoc
@@ -1,3 +1,8 @@
+---
+title: "Assuring 4diac FORTE Code Quality"
+url: doc/development/forte_codequality.html
+---
+
 = [[topOfPage]]Assuring 4diac FORTE Code Quality
 :lang: en
 
@@ -137,10 +142,10 @@ Write positive and negative test cases for your unit tests.
 
 Go back to Development index:
 
-xref:./index.adoc[Development Index]
+xref:./development.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/forte_communicationArchitecture.adoc
+++ b/src/development/forte_communicationArchitecture.adoc
@@ -1,9 +1,11 @@
+---
+title: "Communication Architecture"
+url: doc/development/forte_communicationArchitecture.html
+---
+
 = [[topOfPage]]Communication Architecture
 :lang: en
-:imagesdir: ./src/development/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == Layered Network Interface
 
@@ -309,10 +311,10 @@ We only show a few of the methods here, for more information check source code.
 
 Go back to Development index:
 
-xref:./index.adoc[Development Index]
+xref:./development.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/forte_monitoring.adoc
+++ b/src/development/forte_monitoring.adoc
@@ -1,4 +1,9 @@
-= [[topOfPage]]Development - Monitoring
+---
+title: "Monitoring"
+url: doc/development/forte_monitoring.html
+---
+
+= [[topOfPage]]Monitoring
 :lang: en
 
 DTD will be added, after finishing all the implementation work and the interface for all commands is stable. 
@@ -61,10 +66,10 @@ Currently the following monitoring commands are supported:
 
 Go back to Development index:
 
-link:./index.adoc[Development Index]
+link:./development.adoc[Development Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/ideUpdateTargetPlatform.asciidoc
+++ b/src/development/ideUpdateTargetPlatform.asciidoc
@@ -1,3 +1,8 @@
+---
+title: "Updating the Target Platform used by 4diac IDE"
+url: doc/development/ideUpdateTargetPlatform.html
+---
+
 = [[topOfPage]]Updating the Target Platform used by 4diac IDE
 :lang: en
 

--- a/src/development/libraryManagement.adoc
+++ b/src/development/libraryManagement.adoc
@@ -1,9 +1,11 @@
+---
+title: "Library Management"
+url: doc/development/libraryManagement.html
+---
+
 = [[topOfPage]]Library Management
 :lang: en
-:imagesdir: ./src/development/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 image::LibraryExample.png[Library Example]
 

--- a/src/development/swtBotTestsDocumentation.asciidoc
+++ b/src/development/swtBotTestsDocumentation.asciidoc
@@ -1,9 +1,11 @@
+---
+title: "SWTBot Tests Documentation"
+url: doc/development/swtBotTestsDocumentation.html
+---
+
 = [[topOfPage]]SWTBot Tests Documentation
 :lang: en
-:imagesdir: ./src/development/img/SWTBot
-ifdef::env-github[]
 :imagesdir: img/SWTBot
-endif::[]
 
 * link:#ImprovementThroughAutomatedTesting[Eclipse 4diac IDE User Interface Quality Improvement Through Automated Testing]
 ** link:#WhatIsEclipseSWTBot[What is Eclipse SWTBot]
@@ -123,6 +125,6 @@ Investigations revealed that the bug has already been reported, so no further ac
 
 image:TestResults.png[Test results,width=800]
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/development/swtBotTestsStructure.asciidoc
+++ b/src/development/swtBotTestsStructure.asciidoc
@@ -1,9 +1,11 @@
+---
+title: "SWTBot UI Test Set and Test Structure"
+url: doc/development/swtBotTestsStructure.html
+---
+
 = [[topOfPage]]SWTBot UI Test Set and Test Structure
 :lang: en
-:imagesdir: ./src/development/img/SWTBot
-ifdef::env-github[]
 :imagesdir: img/SWTBot
-endif::[]
 
 * link:#SWTBotTestStructure[Where are the SWTBot UI tests located in the 4diac IDE source code?]
 * link:#SWTBotHierachy[SWTBot Hierachy with Extentions for 4diac IDE]

--- a/src/doc_overview.adoc
+++ b/src/doc_overview.adoc
@@ -1,9 +1,11 @@
+---
+title: "Documentation"
+url: doc/doc_overview.html
+---
+
 = [[topOfPage]] Eclipse 4diac Documentation
 :lang: en
-:imagesdir: ./src/intro/img
-ifdef::env-github[]
 :imagesdir: intro/img
-endif::[]
 
 == How to contribute to this document
 
@@ -32,17 +34,17 @@ To use Eclipse 4diac, you need to understand the terms of the IEC 61499 standard
 At first, take therefore a look at this explanation about the standards and technology related to Eclipse 4diac.
 * xref:./intro/4diacFramework.adoc[Understand the 4diac framework]: 
 If you know about IEC 61499 and what PLCs are, but you don't understand what 4diac IDE is, or what's the relation with 4diac FORTE, then you should take a look at this topic about the 4diac IDE framework.
-* xref:./tutorials/index.adoc[Step by Step Tutorials]: 
+* xref:./tutorials/tutorials.adoc[Step by Step Tutorials]: 
 To understand the basics of 4diac IDE, it is best to start using it.
-* xref:./installation/index.adoc[Install Eclipse 4diac]: 
+* xref:./installation/installation.adoc[Install Eclipse 4diac]: 
 If you understand all of the above, and you want to start using Eclipse 4diac, you will need to first install it.
-* xref:./examples/index.adoc[4diac IDE examples]: 
+* xref:./examples/examples.adoc[4diac IDE examples]: 
 If you want to see some examples using 4diac IDE, this link is your friend.
-* xref:./io_config/index.adoc[IO Configuration for the different platforms]: 
+* xref:./io_config/io_config.adoc[IO Configuration for the different platforms]: 
 If you have a specific platform with input and outputs that is supported by 4diac FORTE, for example a Raspberry Pi or a PLC, and you want to use them, use this topic.
-* xref:./communication/index.adoc[Communication Protocols]: 
+* xref:./communication/communication.adoc[Communication Protocols]: 
 If you want to use a specific communication protocol supported by 4diac FORTE, for example MQTT, OPC UA, Modbus and so on, follow the link.
-* xref:./development/index.adoc[Development of 4diac FORTE and 4diac IDE]: 
+* xref:./development/development.adoc[Development of 4diac FORTE and 4diac IDE]: 
 If you are a developer or you want to know more deep stuff about 4diac FORTE or 4diac IDE, you'll have fun here.
 * https://github.com/eclipse-4diac[File a bug for 4diac FORTE or 4diac IDE]: 
 You found a bug? File it here.

--- a/src/examples/bbbTrafficControl.adoc
+++ b/src/examples/bbbTrafficControl.adoc
@@ -1,9 +1,11 @@
+---
+title: "Run the controller of the traffic light example in the BeagleBoardBlack (BBB)"
+url: doc/examples/bbbTrafficControl.html
+---
+
 = [[topOfPage]]Run the controller of the traffic light example in the BeagleBoardBlack (BBB)
 :lang: en
-:imagesdir: ./src/examples/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 A good practice to get used to the 4diac IDE and the concept of distributed automation, is to apply the Traffic Light example, but instead of running completely in a computer or other platform, we will put the controller part of the Traffic Light example into the BBB, and the lights and Enable/Disable buttons will run in a normal computer using the FBRT runtime.
 
@@ -130,11 +132,11 @@ After that everything should work fine.
 
 Go back to Examples index:
 
-xref:./index.adoc[Examples Index]
+xref:./examples.adoc[Examples Index]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 link:#topOfPage[Go to top]

--- a/src/examples/examples.adoc
+++ b/src/examples/examples.adoc
@@ -1,4 +1,9 @@
-= [[topOfPage]]4diac Examples
+---
+title: "Examples"
+url: doc/examples/examples.html
+---
+
+= [[topOfPage]]Eclipse 4diac Examples
 :lang: en
 
 This page is intended to serve as index for 4diac examples that help understand and develop applications. 
@@ -24,4 +29,4 @@ For the following examples, you'll need specific hardware to try them:
   This is the Traffic Control that comes with Eclipse 4diac, but instead of running locally, the control runs on a BBB and the HMI locally. 
   This example is important because it finds many networking issues that are solved.
 
-Go to xref:../index.adoc[Where to Start]
+Go to xref:../doc_overview.adoc[Where to Start]

--- a/src/examples/pidMotor.adoc
+++ b/src/examples/pidMotor.adoc
@@ -1,9 +1,11 @@
-= [[topOfPage]] Implement a PID controller for the position of an EV3 motor
+---
+title: "Implement a PID Controller for the Position of an EV3 motor"
+url: doc/examples/pidMotor.html
+---
+
+= [[topOfPage]] Implement a PID Controller for the Position of an EV3 motor
 :lang: en
-:imagesdir: ./src/examples/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 In this tutorial, an implementation of a PID controller for an EV3 motor is presented. 
@@ -296,10 +298,10 @@ image:pidMotor/PIDTuned.png[Final tun of the PID controller]
 
 Go back to Examples index:
 
-link:./index.adoc[Examples Index]
+link:./examples.adoc[Examples Index]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 link:#topOfPage[Go to top]

--- a/src/examples/xplus3.adoc
+++ b/src/examples/xplus3.adoc
@@ -1,9 +1,11 @@
+---
+title: "X+3 Tutorial"
+url: doc/examples/xplus3.html
+---
+
 = [[topOfPage]] X+3 Tutorial
 :lang: en
-:imagesdir: ./src/examples/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == Explore an Existing System
 
@@ -148,11 +150,11 @@ To download and test your IEC 61499 [.element61499]#Application#:
 
 Go back to Examples index:
 
-xref:./index.adoc[Examples Index]
+xref:./examples.adoc[Examples Index]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 link:#topOfPage[Go to top]

--- a/src/faq.adoc
+++ b/src/faq.adoc
@@ -1,4 +1,9 @@
-= [[topOfPage]] Eclipse 4diac FAQ
+---
+title: "Eclipse 4diac FAQs"
+url: doc/faq.html
+---
+
+= [[topOfPage]] Eclipse 4diac FAQs
 
 == 4diac IDE FAQ
 
@@ -165,4 +170,4 @@ The message indicates the end of the download process when 4diac IDE disconnect
 
 link:#topOfPage[Go to top]
 
-Or xref:./index.adoc[Go to the Start Here Page]
+Or xref:./doc_overview.adoc[Go to the Start Here Page]

--- a/src/installation/bootWithForte.adoc
+++ b/src/installation/bootWithForte.adoc
@@ -1,3 +1,8 @@
+---
+title: "Start 4diac FORTE after boot on Linux based systems"
+url: doc/installation/bootWithForte.html
+---
+
 = [[topOfPage]]Start 4diac FORTE after boot on Linux based systems
 :lang: en
 
@@ -87,11 +92,11 @@ xref:../tutorials/overview.adoc[Step by step tutorial]
 
 If you want to build 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/docker.adoc
+++ b/src/installation/docker.adoc
@@ -1,3 +1,8 @@
+---
+title: "Building 4diac FORTE Docker Images"
+url: doc/installation/docker.html
+---
+
 = [[topOfPage]]Building 4diac FORTE Docker Images
 :lang: en
 
@@ -84,11 +89,11 @@ xref:../tutorials/overview.adoc[Step by step tutorial]
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/eclipse.adoc
+++ b/src/installation/eclipse.adoc
@@ -1,9 +1,11 @@
+---
+title: "Compiling and Debugging 4diac FORTE with Eclipse"
+url: doc/installation/eclipse.html
+---
+
 = [[topOfPage]]Compiling and Debugging 4diac FORTE with Eclipse
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == Get C/C++ support for Eclipse
 
@@ -20,7 +22,7 @@ image:eclipseInstallNewSoftware.png[Install new software in Eclipse]
 
 == Compile 4diac FORTE with Eclipse
 
-The build process is described in the xref:./index.adoc#FORTEsteps[installation tutorial]. 
+The build process is described in the xref:./installation.adoc#FORTEsteps[installation tutorial]. 
 Perform the steps described there but consider the following adaption:
 
 When generating a project with CMake you must choose the correct project type. 
@@ -66,7 +68,7 @@ image:eclipseDebug.png[Eclipse C++ Debug View]
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 After you installed all required tools, it's time to start using them.
 Take a look at the following page:
@@ -76,6 +78,6 @@ xref:../tutorials/overview.adoc[Step by step tutorial]
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/freeRTOSLwIP.adoc
+++ b/src/installation/freeRTOSLwIP.adoc
@@ -1,9 +1,11 @@
+---
+title: "Building 4diac FORTE for freeRTOS + LwIP"
+url: doc/installation/freeRTOSLwIP.html
+---
+
 = [[topOfPage]]Building 4diac FORTE for freeRTOS + LwIP
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 == Introduction
@@ -154,11 +156,11 @@ xref:../tutorials/overview.adoc[Step 0 - 4diac IDE Overview]
 
 If you want to compile 4diac FORTE for another platform or want to know more about that, here's a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/installation.adoc
+++ b/src/installation/installation.adoc
@@ -1,9 +1,11 @@
+---
+title: "Installation"
+url: doc/installation/installation.html
+---
+
 = [[topOfPage]]Installation
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 == [[IDE]]4diac IDE
 
@@ -23,7 +25,7 @@ This option aims mainly at 4diac IDE developers or people who wish to extend 4d
 4diac FORTE can be used in two ways: For conducting first experiments with Eclipse 4diac, you can use the pre-built version of 4diac FORTE which is available as https://eclipse.dev/4diac/en_dow.php[download] for Linux and Windows. 
 It can be used for applications unless you need own Function Blocks. 
 The step by step tutorial will direct you to making a simple application with 4diac IDE and pre-built 4diac FORTE. 
-If you want to start using 4diac IDE right away, you can skip the rest of the page and go directly to the xref:../tutorials/overview.adoc[step by step tutorial] or the xref:../index.adoc[Start Here-page].
+If you want to start using 4diac IDE right away, you can skip the rest of the page and go directly to the xref:../tutorials/overview.adoc[step by step tutorial] or the xref:../doc_overview.adoc[Start Here-page].
 
 If you want to develop your own Function Blocks or to run 4diac FORTE on control devices, you have to download and set up 4diac FORTE for the specific platform you are using as shown in the next sections.
 
@@ -240,6 +242,6 @@ xref:../tutorial/overview.adoc[Step 0 - 4diac IDE Overview]
 
 If you want to go back to the Where to Start page, we leave you here a fast access:
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/legoMindstormEv3.adoc
+++ b/src/installation/legoMindstormEv3.adoc
@@ -1,3 +1,8 @@
+---
+title: "Using Eclipse 4diac with a Lego Mindstorm EV3"
+url: doc/installation/legoMindstormEv3.html
+---
+
 = [[topOfPage]]Using Eclipse 4diac with a Lego Mindstorm EV3
 :lang: en
 
@@ -112,7 +117,7 @@ Next, you should go into the bin/ev3dev folder and simply execute "make" to star
 If you want to compile directly in your EV3, then start at step 4 and perform everything with the command prompt of your EV3 (to get the command prompt inside of your EV3, connect to it with PuTTY).
 
 Remember, when you create your own FBs, you should add these to the 4diac FORTE folder, adjust the CMakefiles.txt and compile again. 
-In the link:./index.adoc#ownFORTE[example] section, it is explained how to do this.
+In the link:./installation.adoc#ownFORTE[example] section, it is explained how to do this.
 
 == Troubleshooting
 
@@ -141,7 +146,7 @@ In this case, a module called "EV3" is added.
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 After you installed all required tools, it's time to start using them. 
 Take a look at the tutorials - a step by step guide:
@@ -151,6 +156,6 @@ xref:../tutorials/overview.adoc[Step 0 - 4diac IDE Overview]
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/minGW.adoc
+++ b/src/installation/minGW.adoc
@@ -1,3 +1,8 @@
+---
+title: "Setting up MinGW-w64"
+url: doc/installation/minGW.html
+---
+
 = [[topOfPage]]Setting up MinGW-w64
 :lang: en
 
@@ -50,7 +55,7 @@ This is because this file is the one you will use to compile 4diac FORTE, and "
 
 == Next steps
 
-Now that you successfully installed a compiler, you can continue with the next step of the xref:./index.adoc#FORTEsteps[installation tutorial]. 
+Now that you successfully installed a compiler, you can continue with the next step of the xref:./installation.adoc#FORTEsteps[installation tutorial]. 
 All information in the installation tutorial is based on a setup with MinGW-w64. 
 For users with previous experience in building a 4diac FORTE, the details are listed:
 
@@ -63,11 +68,11 @@ For users with previous experience in building a 4diac FORTE, the details are l
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 link:#topOfPage[Go to top]

--- a/src/installation/pikeos_posix.adoc
+++ b/src/installation/pikeos_posix.adoc
@@ -1,9 +1,11 @@
+---
+title: "Setting up 4diac FORTE for Posix PikeOS 5.x"
+url: doc/installation/pikeos_posix.html
+---
+
 = [[topOfPage]]Setting up 4diac FORTE for Posix PikeOS 5.x
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 This instruction assumes you have a Linux system with a PikeOS 5.x installation and a CODOE installation matching to the installed PikeOS
@@ -149,9 +151,9 @@ Repeat this procedure for `POSIX Process`.
 |===
 | Key | Value | Example for QEMU with Usermode NW | Example for QEMU with TUN/TAP NW |
 
-|Interface Address | e.g. "POSIX Process" +1 | 10.0.2.17 | 192.168.0.4 
-|Netmask | 255.x.x.x | 255.255.255.0 | 255.255.255.0  
-|Gateway address | Gateway in target NW to reach the host | 10.0.2.2 | 192.168.0.1 
+|Interface Address | e.g. "POSIX Process" +1 | 10.0.2.17 | 192.168.0.4
+|Netmask | 255.x.x.x | 255.255.255.0 | 255.255.255.0
+|Gateway address | Gateway in target NW to reach the host | 10.0.2.2 | 192.168.0.1
 |===
 
 Now the project looks like this:

--- a/src/installation/raspi.adoc
+++ b/src/installation/raspi.adoc
@@ -1,9 +1,11 @@
+---
+title: "Building 4diac FORTE on Raspberry Pi"
+url: doc/installation/raspi.html
+---
+
 = [[topOfPage]]Building 4diac FORTE on Raspberry Pi
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 == Introduction
@@ -179,10 +181,10 @@ xref:../tutorials/overview.adoc[Step 0 - 4diac IDE Overview]
 
 If you want to compile 4diac FORTE for another platform or want to know more about that, here's a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 If you want to go back to the Start Here page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/visualStudio.adoc
+++ b/src/installation/visualStudio.adoc
@@ -1,21 +1,23 @@
-= [[topOfPage]]Compiling and Debugging 4diac FORTEwith MS Visual Studio
+---
+title: "Compiling and Debugging 4diac FORTE with MS Visual Studio"
+url: doc/installation/visualStudio.html
+---
+
+= [[topOfPage]]Compiling and Debugging 4diac FORTE with MS Visual Studio
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 The following describes how to compile 4diac FORTE with win32-architecture using Visual Studio. 
-In the installation tutorial xref:./index.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
+In the installation tutorial xref:./installation.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
 Additionally, other tools are described there.
 
 IMPORTANT: If you are using a Visual Studio version older then 2010 you might need to extend it with a stdint.h file. 
 See for example http://stackoverflow.com/questions/12970293/why-microsoft-visual-studio-cannot-find-stdint-h[here.]
 
-== Building a MS Visual Studio Project for 4diac FORTEwith CMake
+== Building a MS Visual Studio Project for 4diac FORTE with CMake
 
-In the xref:./index.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
+In the xref:./installation.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
 To use Visual Studio, you need to however select the tool MS Visual Studio. 
 The correct architecture is Win32.
 
@@ -25,23 +27,23 @@ The correct architecture is Win32.
 . Press the [.button4diac]#Configure# button and choose the version of Visual Studio that is used and native default compilers. 
   Press the [.button4diac]#Finish# button afterwards.
 . For the option [.specificText]#FORTE_ARCHITECTURE#, select Win32. 
-  Other modules and configurations options can be set following the tutorial step link:./index.adoc#generateFilesForCompiling[Build a project with CMake].
+  Other modules and configurations options can be set following the tutorial step link:./installation.adoc#generateFilesForCompiling[Build a project with CMake].
 . Press the [.button4diac]#Configure# button, check red rows and repeat this until no row appears red. Afterwards, press the button [.button4diac]#Generate#.
 
-== Compile 4diac FORTEwith Visual Studio
+== Compile 4diac FORTE with Visual Studio
 
-. Open the generated 4diac FORTEproject (.sln file) with Visual Studio in `FORTE_FOLDER_ROOT/bin/win32`. 
+. Open the generated 4diac FORTE project (.sln file) with Visual Studio in `FORTE_FOLDER_ROOT/bin/win32`. 
   You can change from Debug to Release mode if you don't want to debug.
 +
 image:VSreleaseDebug.png[Release Mode of Visual Studio ]
-. Build 4diac FORTEafterwards by right-clicking on [.button4diac]#forte# in the Solution Explorer window and then clicking [.button4diac]#Build#.
+. Build 4diac FORTE afterwards by right-clicking on [.button4diac]#forte# in the Solution Explorer window and then clicking [.button4diac]#Build#.
   A file `forte.exe` should be generated in `FORTE_FOLDER_ROOT/bin/win32/src/Release`.
 +
 image:VSCompile.png[Compile by right-clicking on 4diac FORTE in the Solution Explorer window, and then click Build]
 
 == Debugging
 
-. If you want to Debug using Visual Studio, select the Debug mode and set 4diac FORTEas the main project.
+. If you want to Debug using Visual Studio, select the Debug mode and set 4diac FORTE as the main project.
 +
 image:VSstartProject.png[Set 4diac FORTE as main project in Visual Studio ]
 . Finally, press [.button4diac]#F5# or click [.button4diac]#Debug → Start Debugging#
@@ -51,7 +53,7 @@ image:VSstartProject.png[Set 4diac FORTE as main project in Visual Studio ]
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 After you installed all required tools, it's time to start using them.
 Take a look at the following page:
@@ -61,6 +63,6 @@ xref:../tutorials/overview.adoc[Step by step tutorial]
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/visualStudioCode.adoc
+++ b/src/installation/visualStudioCode.adoc
@@ -1,20 +1,22 @@
+---
+title: "Compiling and Debugging 4diac FORTE with MS Visual Studio Code"
+url: doc/installation/visualStudioCode.html
+---
+
 = [[topOfPage]]Compiling and Debugging 4diac FORTE with MS Visual Studio Code
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 The following describes how to compile 4diac FORTE with win32-architecture using Visual Studio Code. 
-In the installation tutorial xref:./index.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
+In the installation tutorial xref:./installation.adoc#ownFORTE[(back)] you find more details on building your own 4diac FORTE. 
 Additionally, visual studio code is described there.
 
 == Building a MS Visual Studio Code Project for 4diac FORTE with CMake
 
-In the xref:./index.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
+In the xref:./installation.adoc#ownFORTE[installation tutorial], the steps on building a project with CMake are described in detail. 
 To use Visual Studio Code with CMake, you need to specify the options (All the options are shown in CMake-GUI when you choose source
-folder FORTE_FOLDER_ROOT, refer to xref:./index.adoc#generateFilesForCompiling[Build a project with CMake].) for CMake in settings.json for the project in Visual Studio Code.
+folder FORTE_FOLDER_ROOT, refer to xref:./installation.adoc#generateFilesForCompiling[Build a project with CMake].) for CMake in settings.json for the project in Visual Studio Code.
 The correct architecture is Win32. 
 Below is an example of settings.json for forte with OPC DA compiled.
 
@@ -62,7 +64,7 @@ image:visualcodeDebug.png[debug or release]
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 After you installed all required tools, it's time to start using them.
 Take a look at the following page:
@@ -72,6 +74,6 @@ xref:../tutorials/overview.adoc[Step by step tutorial]
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/installation/wago.adoc
+++ b/src/installation/wago.adoc
@@ -1,9 +1,11 @@
+---
+title: "Building 4diac FORTE for Wago"
+url: doc/installation/wago.html
+---
+
 = [[topOfPage]]Building 4diac FORTE for Wago
 :lang: en
-:imagesdir: ./src/installation/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 == Introduction
@@ -170,11 +172,11 @@ xref:../tutorials/overview.adoc[Step by step tutorial]
 
 If you want to build a 4diac FORTE, here is a quick link back:
 
-xref:./index.adoc[Install Eclipse 4diac]
+xref:./installation.adoc[Install Eclipse 4diac]
 
 If you want to go back to the Start Here page, we leave you here a fast
 access
 
-xref:../index.adoc[Start Here page]
+xref:../doc_overview.adoc[Start Here page]
 
 Or link:#topOfPage[Go to top]

--- a/src/intro/4diacFramework.adoc
+++ b/src/intro/4diacFramework.adoc
@@ -1,9 +1,11 @@
+---
+title: "The Eclipse 4diac Project"
+url: doc/intro/4diacFramework.html
+---
+
 = [[topOfPage]]The Eclipse 4diac Project
 :lang: en
-:imagesdir: ./src/intro/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 To understand what's next, you need to know IEC 61499. 
 If you did not read the following page yet, go there now: xref:iec61499.adoc[IEC 61499 101]
@@ -53,7 +55,7 @@ As described, you can create FBs in 4diac IDE.
 At this point, however, the run-time environment doesn't know that the FB exists nor how to execute it. 
 Within 4diac IDE, you therefore have the possibility to export your created FB into 4diac FORTE code (i.e., C++ files). 
 You then need to add your exported code to the source code of 4diac FORTE and compile all as explained in the
-xref:../installation/index.adoc#FORTE[Compile 4diac FORTE] section of the installation documentation. 
+xref:../installation/installation.adoc#FORTE[Compile 4diac FORTE] section of the installation documentation. 
 This is possible only for Basic and Composite Function Blocks (BFB and CFB), since both definitions are in the standard. 
 However, for Service Interface Function Blocks (SIFBs) only the interface is defined. 
 The internal implementation of an SIFB has to be coded manually in C++, the language 4diac FORTE is written in.
@@ -69,8 +71,8 @@ Currently, the most commonly used protocols are MQTT or OPC UA.
 
 * Now that you have a better understanding of the IEC 61499 standard, and know about the tools around Eclipse 4diac, is time to start using them.
 Take a look at the following page: +
-xref:../installation/index.adoc[Installation]
+xref:../installation/installation.adoc[Installation]
 * If you want to go back to the Where to Start page, we leave you here a fast access: +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/intro/iec61499.adoc
+++ b/src/intro/iec61499.adoc
@@ -1,9 +1,11 @@
+---
+title: "IEC 61499 101"
+url: doc/intro/iec61499.html
+---
+
 = [[topOfPage]]IEC 61499 101
 :lang: en
-:imagesdir: ./src/intro/img
-ifdef::env-github[]
-:imagesdir: img
-endif::[]
+:imagesdir: ./img
 
 
 == [[PLC]]PLC Programming according to IEC 61131-3
@@ -11,7 +13,7 @@ endif::[]
 A https://en.wikipedia.org/wiki/Programmable_logic_controller[PLC] is, basically, a small computer used in industry. 
 It has inputs and outputs for controlling various systems. 
 In general, buttons and sensors generate the inputs, while the outputs control motors. 
-If you have an IT background, you may want to imagine a PLC as a https://www.raspberrypi.org/[Raspberry Pi], an https://www.arduino.cc/ [Arduino], a https://beagleboard.org/[Beagle Bone Black] or a similar embedded board with inputs and outputs. 
+If you have an IT background, you may want to imagine a PLC as a https://www.raspberrypi.org/[Raspberry Pi], an https://www.arduino.cc/[Arduino], a https://beagleboard.org/[Beagle Bone Black] or a similar embedded board with inputs and outputs. 
 A PLC is however specifically prepared for use in industry. 
 The PLC is programmed according to the required application. 
 Like computers, PLCs can be acquired from many different manufacturers. 
@@ -240,6 +242,6 @@ You can see the Compliance Profile as a way of filling the gaps due to the abstr
 * Now that you have a better understanding of the IEC 61499 standard, it's time to understand what Eclipse 4diac is and which tools are related to it. Take a look at the following page: +
 xref:4diacFramework.adoc[Eclipse 4diac Framework]
 * In case you'd like to return to the "Where to Start"-page, we leave here a fast access for you: +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/EV3.adoc
+++ b/src/io_config/EV3.adoc
@@ -1,9 +1,14 @@
+---
+title: "Lego Mindstorms EV3"
+url: doc/io_config/EV3.html
+---
+
 = [[ev3]]Lego Mindstorms EV3
 
 This section is a reference of the parameters that can be used in 4diac FORTE to access the I/O of the LMSEV3. 
 Reading this section carefully without using them could be quite boring and even useless, because the details will be forgotten if not used. 
 We recommend to give a quick reading in order to know what can be accessed using 4diac FORTE. 
-The link:..//examples/pidMotor.adoc[example] presents the control of a motor using a PID controller.
+The xref:../examples/pidMotor.adoc[example] presents the control of a motor using a PID controller.
 
 
 == [[ev3_standard_parameters]]Standard Access
@@ -313,14 +318,14 @@ Example: 58
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/Odroid.adoc
+++ b/src/io_config/Odroid.adoc
@@ -1,9 +1,11 @@
+---
+title: "Odroid"
+url: doc/io_config/Odroid.html
+---
+
 = [[odroid]]Odroid
 :lang: en
-:imagesdir: ./src/io_config/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 https://wiki.odroid.com/[Odroid] is an embedded board that you can say it's a more powerful Rapsberry Pi, and it has analog inputs. 
 In order to use the I/O of this board. 
@@ -16,14 +18,14 @@ image:odroidFBs.png[FBs example for Odroid platform]
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/PiFace.adoc
+++ b/src/io_config/PiFace.adoc
@@ -1,3 +1,8 @@
+---
+title: "PiFace Digital 2"
+url: doc/io_config/PiFace.html
+---
+
 = [[piface]]PiFace Digital 2
 
 The http://www.piface.org.uk/products/piface_digital_2/[PiFace 2] is a hat for the Raspberry Pi with Digital I/Os. 
@@ -10,14 +15,14 @@ https://github.com/eclipse-4diac/4diac-forte/issues[issue].
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/RevolutionPi.adoc
+++ b/src/io_config/RevolutionPi.adoc
@@ -1,9 +1,11 @@
+---
+title: "Revolution Pi"
+url: doc/io_config/RevolutionPi.html
+---
+
 = [[RevolutionPi]]Revolution Pi
 :lang: en
-:imagesdir: ./src/io_config/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 The Revolution Pi by KUNBUS GmbH has been implemented by the _IO_CONFIG_ based I/O concept.
 Revolution Pi is a modular PLC, where you always have at least one core module and maybe one or more expansion modules for I/Os.
@@ -75,14 +77,14 @@ When all I/Os are wired and named within your _IO_CONFIG_ function block network
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/SysFs.adoc
+++ b/src/io_config/SysFs.adoc
@@ -1,9 +1,11 @@
+---
+title: "SysFs (Raspberry Pi, Beagle Bone Black and Similar Boards)"
+url: doc/io_config/SysFs.html
+---
+
 = [[sysfs]]SysFs (Raspberry Pi, Beagle Bone Black and Similar Boards)
 :lang: en
-:imagesdir: ./src/io_config/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 The following picture shows an example application from the xref:../tutorials/use4diacLocally.adoc[Blinking tutorial] which is extended with IX and QX function blocks. 
 The extended application periodically toggles on pin number 8. 
@@ -24,14 +26,14 @@ Remember that if you have any problem and cannot find the solution in the docume
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/io_config.adoc
+++ b/src/io_config/io_config.adoc
@@ -1,3 +1,8 @@
+---
+title: "I/O Configuration for Different Platforms"
+url: doc/io_config/io_config.html
+---
+
 = [[topOfPage]]I/O Configuration for Different Platforms
 :lang: en
 
@@ -41,14 +46,14 @@ For the supported platforms have a look on the following chapters:
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/mlpi.adoc
+++ b/src/io_config/mlpi.adoc
@@ -1,3 +1,8 @@
+---
+title: "Bosch Rexroth PLC (MLPI)"
+url: doc/io_config/mlpi.html
+---
+
 == [[mlpi]]Bosch Rexroth PLC (MLPI)
 
 The MLPI interface was tested on a http://www.boschrexroth.com/dcc/Vornavigation/VorNavi.cfm?PageID=p650746&Language=en[IndraControl
@@ -18,14 +23,14 @@ An example was tested where the Digital Inputs were called di01, di01, di02 and 
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/plc01a1.adoc
+++ b/src/io_config/plc01a1.adoc
@@ -1,3 +1,8 @@
+---
+title: "Use the PLC01A1 Module from STM32"
+url: doc/io_config/plc01a1.html
+---
+
 = Use the PLC01A1 Module from STM32
 :lang: en
 
@@ -164,14 +169,14 @@ which saves the current log and the previous one, in case the board reboots.
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/io_config/uMIC.adoc
+++ b/src/io_config/uMIC.adoc
@@ -1,9 +1,11 @@
+---
+title: "µMIC.200"
+url: doc/io_config/uMIC.html
+---
+
 = [[umic]]µMIC.200
 :lang: en
-:imagesdir: ./src/io_config/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This module uses the library provided for the http://www.microcontrol.net/en/products/control-systems/umic200/[µMIC.200].
 You need the `umic_dio.h`, `umic_relay.h` and `umic_led.h` headers and also the `umic.so` library to be present in your system and accessible by the compiler.
@@ -71,14 +73,14 @@ If you don't want to use the relay and led, or you don't want to change the head
 
 You can see the supported protocols:
 
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 
 You can see the examples:
 
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 
 If you want to go back to the Where to Start page, we leave you here a fast access
 
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 Or link:#topOfPage[Go to top]

--- a/src/tutorials/advancedFeatures.adoc
+++ b/src/tutorials/advancedFeatures.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 6 - Advanced Features"
+url: doc/tutorials/advancedFeatures.html
+---
+
 = [[topOfPage]]Step 6 - Advanced Features
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This page is part of a guide that gives a walk-through over the major
 4diac IDE features.
@@ -73,14 +75,14 @@ Further examples for the usage of adapters can be found within the FestoMPS exam
 == Where to go from here?
 
 * If you want to see some examples, behind the following link is an index of the available examples in the documentation: +
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 * If you have a specific platform that has input and outputs and is supported by 4diac FORTE, for example a Raspberry Pi or a PLC, and you want to use them, go to following page: +
 xref:../io_config/io_config.adoc[Parameters for Different Platforms]
 * If you want to use a specific communication protocol supported by 4diac FORTE, for example MQTT, OPC UA, Modbus and so on, go this page: +
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 * If you want to go back to see again the basic features, here's a link: +
 xref:./otherUseful.adoc[Step 5 - Other Basic Features]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc#wheretostart[Where to Start]
+xref:../doc_overview.adoc#wheretostart[Where to Start]
 
 link:#topOfPage[Go to top]

--- a/src/tutorials/createOwnTypes.adoc
+++ b/src/tutorials/createOwnTypes.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 4 - Create Your own Function Block Types"
+url: doc/tutorials/createOwnTypes.html
+---
+
 = [[topOfPage]]Step 4 - Create Your own Function Block Types
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 This page is part of a guide that gives a walk-through of the major 4diac IDE features.
@@ -290,6 +292,6 @@ xref:./otherUseful.adoc[Step 5 - Other Basic Features]
 * If you want to go back to the distributed application running remotely, here's a link +
 xref:./use4diacRemotely.adoc[Step 3 - Deploy Applications Remotely]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 link:#topOfPage[Go to top]

--- a/src/tutorials/distribute4diac.adoc
+++ b/src/tutorials/distribute4diac.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 2 - Distribute 4diac Applications"
+url: doc/tutorials/distribute4diac.html
+---
+
 = [[topOfPage]]Step 2 - Distribute 4diac Applications
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 
 This page is part of a guide that gives a walk-through over the major 4diac IDE features.
@@ -133,6 +135,6 @@ xref:./use4diacRemotely.adoc[Step 3 - Deploy Applications Remotely]
 * If you want to go back to the original Blinking application without buttons, here's a link +
 link:./use4diacLocally.adoc[Step 1 - Use 4diac Locally (Blinking Tutorial)]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 link:#topOfPage[Go to top]

--- a/src/tutorials/dynamicTypeLoader.adoc
+++ b/src/tutorials/dynamicTypeLoader.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 7 - Deploying new FBs with the Dynamic Type Loader"
+url: doc/tutorials/dynamicTypeLoader.html
+---
+
 = [[topOfPage]]Step 7 - Deploying new FBs with the Dynamic Type Loader
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This page is part of a guide that gives a walk-through of the major 4diac IDE features.
 
@@ -31,7 +33,7 @@ Instead of directly compiled into 4diac FORTE, the FBs are downloaded as LUA Co
 Before we can use the Dynamic Type Loader, we have to compile a new 4diac FORTE with the Lua JIT (Just-In-Time Compiler). 
 Therefore we are going to need a C-compiler. 
 If you have done the tutorial, on how to create your own 4diac FORTE, everything you need should already be installed. 
-Otherwise, follow the steps xref:../installation/index.adoc[here].
+Otherwise, follow the steps xref:../installation/installation.adoc[here].
 
 We recommend using the minGW compiler.
 
@@ -63,7 +65,7 @@ Then create an folder where we are going to build our 4diac FORTE in.
 Open CMake and set the source folder, to the folder where your 4diac FORTE source files are in. 
 Then set the build folder, to folder where you want to build 4diac FORTE in.
 
-Before configuring the Lua options, please enable all options, shown in this xref:../installation/index.adoc#generateFilesForCompiling[tutorial].
+Before configuring the Lua options, please enable all options, shown in this xref:../installation/installation.adoc#generateFilesForCompiling[tutorial].
 Before pressing generate, we have to configure all Lua options.
 
 . Set `FORTE_USE_LUATYPES` to `LUAJIT` and press configure
@@ -97,7 +99,7 @@ Everything should be set up and you can deploy your FBs, like you learned earlie
 == Where to go from here?
 
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc#wheretostart[Where to Start]
+xref:../doc_overview.adoc#wheretostart[Where to Start]
 
 link:#topOfPage[Go to top]
 

--- a/src/tutorials/otherUseful.adoc
+++ b/src/tutorials/otherUseful.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 5 - Other Basic Features"
+url: doc/tutorials/otherUseful.html
+---
+
 = [[CreateTypes]]Step 5 - Other Basic Features
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This page is part of a guide that gives a walk-through over the major 4diac IDE features.
 
@@ -66,15 +68,15 @@ Before using it you need to rename it to forte.fboot.
 * The last step is optional, and shows some advanced features of 4diac IDE that you might use in more complicated applications: +
 xref:./advancedFeatures.adoc[Step 6 - Advanced Features]
 * If you want to see some examples, the following link is an index of the available examples in the documentation: +
-xref:../examples/index.adoc[4diac Examples]
+xref:../examples/examples.adoc[4diac Examples]
 * If you have a specific platform that has input and outputs that is supported by 4diac FORTE, for example a Raspberry Pi or a PLC, and you want to use them, go to following page: +
 xref:../io_config/io_config.adoc[I/O Configuration Parameters for Different Platforms]
 * If you want to use a specific communication protocol supported by 4diac FORTE, for example MQTT, OPC UA, Modbus and so on, go to this
 page: +
-xref:../communication/index.adoc[Supported Communication Protocols]
+xref:../communication/communication.adoc[Supported Communication Protocols]
 * If you want to go back to see again how to create your own Function Blocks, here's a link: +
 xref:./createOwnTypes.adoc[Step 4 - Create Your own Function Block Types]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 link:#topOfPage[Go to top]

--- a/src/tutorials/overview.adoc
+++ b/src/tutorials/overview.adoc
@@ -1,14 +1,16 @@
+---
+title: "Step 0 - 4diac IDE - Overview"
+url: doc/tutorials/overview.html
+---
+
 = [[topOfPage]] Step 0 - 4diac IDE - Overview
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This page is part of a guide that gives a walk-through over the major 4diac IDE features.
 
 [start=0]
-. xref:overview.adoc[4diac IDE Overview (YOU ARE HERE!)]
+. 4diac IDE Overview (YOU ARE HERE!)
 . xref:use4diacLocally.adoc[Use 4diac Locally (Blinking tutorial)]
 . xref:distribute4diac.adoc[Distribute 4diac Applications]
 . xref:use4diacRemotely.adoc[Deploy Applications Remotely]
@@ -151,6 +153,6 @@ First, select the FB by clicking onto it and, then, click on the FB again to edi
 * Now that you got an overview of the major parts of 4diac IDE, you can start using it: +
 xref:use4diacLocally.adoc[Step 1 - Use 4diac IDE Locally]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 link:#topOfPage[Go to top]

--- a/src/tutorials/tutorials.adoc
+++ b/src/tutorials/tutorials.adoc
@@ -1,3 +1,8 @@
+---
+title: "Tutorials"
+url: doc/tutorials/tutorials.html
+---
+
 = Eclipse 4diac Tutorials
 
 == xref:overview.adoc[Step 0 - 4diac IDE Overview]

--- a/src/tutorials/use4diacLocally.adoc
+++ b/src/tutorials/use4diacLocally.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 1 - Use 4diac Locally"
+url: doc/tutorials/use4diacLocally.html
+---
+
 = [[topOfPage]]Step 1 - Use 4diac Locally
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This page is part of a guide that gives a walk-through over the major 4diac IDE features.
 
@@ -217,7 +219,7 @@ Before we test our application, let's briefly summarize the elements we've worke
 In this step, the Blink application will be deployed to 4diac FORTE running locally on your computer.
 
 . You have to select a 4diac FORTE. +
-You can either build your own 4diac FORTE as xref:../installation/index.adoc#ownFORTE[shown here] or you can download the 4diac FORTE image that is provided for you for this tutorial on https://eclipse.dev/4diac/en_dow.php[our Homepage]. 
+You can either build your own 4diac FORTE as xref:../installation/installation.adoc#ownFORTE[shown here] or you can download the 4diac FORTE image that is provided for you for this tutorial on https://eclipse.dev/4diac/en_dow.php[our Homepage]. 
 You can save the .exe wherever you like, we have chosen `F:\4diac\4diac IDE\`. 
 Go to [.menu4diac]#Windows → Preferences → 4diac IDE → FORTE Preferences#, and in [.addressDoc]#FORTE Location# look for the 4diac FORTE executable and then click _Apply and Close_. +
 image:Step1/selectForte.png[select your 4diac FORTE,width=600]
@@ -287,6 +289,6 @@ xref:./distribute4diac.adoc[Step 2 - Distribute 4diac Applications]
 * If you want to go the back to see an overall overview of 4diac IDE, here's a link +
 xref:./overview.adoc[Step 0 - 4diac IDE Overview] +
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 link:#topOfPage[Go to top]

--- a/src/tutorials/use4diacRemotely.adoc
+++ b/src/tutorials/use4diacRemotely.adoc
@@ -1,9 +1,11 @@
+---
+title: "Step 3 - Deploy Applications Remotely"
+url: doc/tutorials/use4diacRemotely.html
+---
+
 = [[topOfPage]]Step 3 - Deploy Applications Remotely
 :lang: en
-:imagesdir: ./src/tutorials/img
-ifdef::env-github[]
 :imagesdir: img
-endif::[]
 
 This page is part of a guide that gives a walk-through over the major 4diac IDE features.
 
@@ -31,7 +33,7 @@ image:Step3/remoteArchitecture.png[architecture for the current step]
   The cheap options are Raspberry Pi, BeagleBoneBlack or another small board that runs Linux. 
   Another option would be to use another computer in your network.
 . Compile 4diac FORTE for your PLC or other Hardware. 
-  Check link:..//installation/index.adoc#FORTEWindowsUnix[here] for more information.
+  Check xref:../installation/installation.adoc#FORTEWindowsUnix[here] for more information.
 . Go to the System Configuration of the _BlinkTest_ and change the address from localhost to the IP address of your device. 
   This is the easiest way to interact with an external device. +
   However, certain devices require a special device type. 
@@ -104,6 +106,6 @@ xref:./createOwnTypes.adoc[Step 4 - Create Your own Function Block Types]
 * If you want to go back to the distributed application running completely locally, here's a link: +
 xref:./distribute4diac.adoc[Step 2 - Distribute 4diac Applications]
 * If you want to go back to the Start Here page, we leave you here a fast access +
-xref:../index.adoc[Where to Start]
+xref:../doc_overview.adoc[Where to Start]
 
 link:#topOfPage[Go to top]


### PR DESCRIPTION
Hugo treats directories which have a file called index.* special and will only use this one file. This broke the documentation. Also hugo needs a front matter part to create the right directory structures and html files. This commit adjusts the documentation to handle that.