### PR TITLE
Hugo requires for all menu links to be lower case

### DIFF
--- a/src/intro/4diacFramework.adoc
+++ b/src/intro/4diacFramework.adoc
@@ -1,6 +1,6 @@
 ---
 title: "The Eclipse 4diac Project"
-url: doc/intro/4diacFramework.html
+url: doc/intro/4diacframework.html
 ---
 
 = [[topOfPage]]The Eclipse 4diac Project


### PR DESCRIPTION
In order to adress this the header for 4diac Framework had to be adjusted.