### PR TITLE
Replaced topOfPage links with top #65

### DIFF
--- a/src/communication/arrowhead.adoc
+++ b/src/communication/arrowhead.adoc
@@ -3,7 +3,7 @@ title: "How to use Eclipse 4diac's Arrowhead Library"
 url: doc/communication/arrowhead.html
 ---
 
-= [[topOfPage]]How to use Eclipse 4diac's Arrowhead Library
+= How to use Eclipse 4diac's Arrowhead Library
 :lang: en
 :imagesdir: img
 
@@ -180,4 +180,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/communication.adoc
+++ b/src/communication/communication.adoc
@@ -3,7 +3,7 @@ title: "Supported Communication Protocols"
 url: doc/communication/communication.html
 ---
 
-= [[topOfPage]] Eclipse 4diac Supported Communication Protocols
+=  Eclipse 4diac Supported Communication Protocols
 
 This page is intended to serve as index for communication protocols that
 are supported by 4diac FORTE.

--- a/src/communication/fbdkip.adoc
+++ b/src/communication/fbdkip.adoc
@@ -3,7 +3,7 @@ title: "FBDK/IP"
 url: doc/communication/fbdkip.html
 ---
 
-= [[topOfPage]]FBDK/IP
+= FBDK/IP
 :lang: en
 :imagesdir: img
 
@@ -107,4 +107,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access + 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/http.adoc
+++ b/src/communication/http.adoc
@@ -3,7 +3,7 @@ title: "HTTP"
 url: doc/communication/HTTP.html
 ---
 
-= [[topOfPage]]HTTP
+= HTTP
 
 This section shows how to make applications communicate using the HTTP protocol. 
 You should use the client and server FBs according to your needs.
@@ -68,4 +68,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/modbus.adoc
+++ b/src/communication/modbus.adoc
@@ -3,7 +3,7 @@ title: "Modbus"
 url: doc/communication/modbus.html
 ---
 
-= [[topOfPage]]Modbus
+= Modbus
 :lang: en
 :imagesdir: img
 
@@ -133,4 +133,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/mqttPaho.adoc
+++ b/src/communication/mqttPaho.adoc
@@ -3,7 +3,7 @@ title: "MQTT with Eclipse Paho"
 url: doc/communication/mqttPaho.html
 ---
 
-= [[topOfPage]]MQTT with Eclipse Paho
+= MQTT with Eclipse Paho
 :lang: en
 :imagesdir: img
 
@@ -66,4 +66,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/opcDA.adoc
+++ b/src/communication/opcDA.adoc
@@ -3,7 +3,7 @@ title: "OPC DA"
 url: doc/communication/opcDA.html
 ---
 
-= [[topOfPage]]OPC DA
+= OPC DA
 :lang: en
 :imagesdir: img
 
@@ -107,4 +107,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/opcUA.adoc
+++ b/src/communication/opcUA.adoc
@@ -3,7 +3,7 @@ title: "OPC UA with IEC 61499 Tutorial"
 url: doc/communication/opcUA.html
 ---
 
-= [[topOfPage]]OPC UA with IEC 61499 Tutorial
+= OPC UA with IEC 61499 Tutorial
 :lang: en
 :imagesdir: img
 
@@ -497,4 +497,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/openPOWERLINK.adoc
+++ b/src/communication/openPOWERLINK.adoc
@@ -3,7 +3,7 @@ title: "openPOWERLINK"
 url: doc/communication/openPOWERLINK.html
 ---
 
-= [[topOfPage]]openPOWERLINK
+= openPOWERLINK
 
 http://openpowerlink.sourceforge.net/web/[openPOWERLINK] is an Open Source Industrial Ethernet stack implementing the https://en.wikipedia.org/wiki/Ethernet_Powerlink[Ethernet POWERLINK] protocol.
 
@@ -41,4 +41,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/simulation.adoc
+++ b/src/communication/simulation.adoc
@@ -3,7 +3,7 @@ title: "Communicating with Simulation Tools"
 url: doc/communication/simulation.html
 ---
 
-= [[topOfPage]]Communicating with Simulation Tools
+= Communicating with Simulation Tools
 :lang: en
 :imagesdir: img
 
@@ -106,4 +106,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access + 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/tsn.adoc
+++ b/src/communication/tsn.adoc
@@ -3,7 +3,7 @@ title: "How to use Eclipse 4diac's Time Sensitive Networking Communication Inter
 url: doc/communication/tsn.html
 ---
 
-= [[topOfPage]]How to use Eclipse 4diac's Time Sensitive Networking Communication Interface
+= How to use Eclipse 4diac's Time Sensitive Networking Communication Interface
 :lang: en
 :imagesdir: img
 
@@ -91,4 +91,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/communication/xqueries.adoc
+++ b/src/communication/xqueries.adoc
@@ -3,7 +3,7 @@ title: "Access BaseX Database with XQueries"
 url: doc/communication/xqueries.html
 ---
 
-= [[topOfPage]]Access BaseX Database with XQueries
+= Access BaseX Database with XQueries
 :lang: en
 :imagesdir: img
 
@@ -194,4 +194,4 @@ xref:./communication.adoc[Communication Index]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/building4diac.adoc
+++ b/src/development/building4diac.adoc
@@ -3,7 +3,7 @@ title: "Building and Running 4diac IDE"
 url: doc/development/building4diac.html
 ---
 
-= [[topOfPage]]Building and Running 4diac IDE
+= Building and Running 4diac IDE
 :lang: en
 :imagesdir: img
 
@@ -127,7 +127,7 @@ See link:#buildBinary[Building a binary 4diac IDE package from source] for deta
 
 In addition we offer a nightly build of 4diac IDE https://download.eclipse.org/4diac/updates/nightly/[here].
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 == [[buildBinary]]2 Building a Binary 4diac IDE Package from Source
@@ -149,5 +149,5 @@ Go back to xref:./development.adoc[Development Index]
 
 Go back to xref:../doc_overview.adoc[Eclipse 4diac Documentation page]
  
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]
 

--- a/src/development/contribute.asciidoc
+++ b/src/development/contribute.asciidoc
@@ -3,7 +3,7 @@ title: "Contributing to Eclipse 4diac"
 url: doc/development/contribute.html
 ---
 
-= [[topOfPage]]Contributing to Eclipse 4diac
+= Contributing to Eclipse 4diac
 :lang: en
 :imagesdir: img
 
@@ -565,4 +565,4 @@ If you want to go back to the Start Here page, we leave you here a fast access:
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/development.adoc
+++ b/src/development/development.adoc
@@ -3,7 +3,7 @@ title: "Development of 4diac IDE or 4diac FORTE"
 url: doc/development/development.html
 ---
 
-= [[topOfPage]]Development of 4diac IDE or 4diac FORTE
+= Development of 4diac IDE or 4diac FORTE
 :lang: en
 
 This page is intended to give an overview of the topics you can find in the documentation about developing 4diac IDE or 4diac FORTE.
@@ -22,4 +22,4 @@ This page is intended to give an overview of the topics you can find in the docu
 
 Go to xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/externalEvent_example.adoc
+++ b/src/development/externalEvent_example.adoc
@@ -3,7 +3,7 @@ title: "External Event SIFB"
 url: doc/development/externalEvent_example.html
 ---
 
-= [[topOfPage]]External Event SIFB
+= External Event SIFB
 :lang: en
 :imagesdir: img
 
@@ -125,4 +125,4 @@ If you want to go back to the Start Here page, we leave you here a fast access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/forte_codequality.adoc
+++ b/src/development/forte_codequality.adoc
@@ -3,7 +3,7 @@ title: "Assuring 4diac FORTE Code Quality"
 url: doc/development/forte_codequality.html
 ---
 
-= [[topOfPage]]Assuring 4diac FORTE Code Quality
+= Assuring 4diac FORTE Code Quality
 :lang: en
 
 
@@ -148,4 +148,4 @@ If you want to go back to the Start Here page, we leave you here a fast access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/forte_communicationArchitecture.adoc
+++ b/src/development/forte_communicationArchitecture.adoc
@@ -3,7 +3,7 @@ title: "Communication Architecture"
 url: doc/development/forte_communicationArchitecture.html
 ---
 
-= [[topOfPage]]Communication Architecture
+= Communication Architecture
 :lang: en
 :imagesdir: img
 
@@ -317,4 +317,4 @@ If you want to go back to the Start Here page, we leave you here a fast access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/forte_monitoring.adoc
+++ b/src/development/forte_monitoring.adoc
@@ -3,7 +3,7 @@ title: "Monitoring"
 url: doc/development/forte_monitoring.html
 ---
 
-= [[topOfPage]]Monitoring
+= Monitoring
 :lang: en
 
 DTD will be added, after finishing all the implementation work and the interface for all commands is stable. 
@@ -70,4 +70,4 @@ If you want to go back to the Start Here page, we leave you here a fast access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/ideUpdateTargetPlatform.asciidoc
+++ b/src/development/ideUpdateTargetPlatform.asciidoc
@@ -3,7 +3,7 @@ title: "Updating the Target Platform used by 4diac IDE"
 url: doc/development/ideUpdateTargetPlatform.html
 ---
 
-= [[topOfPage]]Updating the Target Platform used by 4diac IDE
+= Updating the Target Platform used by 4diac IDE
 :lang: en
 
 For upgrading to new Eclipse platform versions the following steps need to be done:

--- a/src/development/libraryManagement.adoc
+++ b/src/development/libraryManagement.adoc
@@ -3,7 +3,7 @@ title: "Library Management"
 url: doc/development/libraryManagement.html
 ---
 
-= [[topOfPage]]Library Management
+= Library Management
 :lang: en
 :imagesdir: img
 

--- a/src/development/swtBotTestsDocumentation.asciidoc
+++ b/src/development/swtBotTestsDocumentation.asciidoc
@@ -3,7 +3,7 @@ title: "SWTBot Tests Documentation"
 url: doc/development/swtBotTestsDocumentation.html
 ---
 
-= [[topOfPage]]SWTBot Tests Documentation
+= SWTBot Tests Documentation
 :lang: en
 :imagesdir: img/SWTBot
 
@@ -127,4 +127,4 @@ image:TestResults.png[Test results,width=800]
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/development/swtBotTestsStructure.asciidoc
+++ b/src/development/swtBotTestsStructure.asciidoc
@@ -3,7 +3,7 @@ title: "SWTBot UI Test Set and Test Structure"
 url: doc/development/swtBotTestsStructure.html
 ---
 
-= [[topOfPage]]SWTBot UI Test Set and Test Structure
+= SWTBot UI Test Set and Test Structure
 :lang: en
 :imagesdir: img/SWTBot
 

--- a/src/doc_overview.adoc
+++ b/src/doc_overview.adoc
@@ -3,7 +3,7 @@ title: "Documentation"
 url: doc/doc_overview.html
 ---
 
-= [[topOfPage]] Eclipse 4diac Documentation
+=  Eclipse 4diac Documentation
 :lang: en
 :imagesdir: intro/img
 
@@ -75,4 +75,4 @@ This application might not be intended for only one device, but for a whole syst
 In that case, some FBs will need to run on one device, and some on others - a distributed system is created.
 With 4diac IDE you can design your distributed application and deploy it.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/examples/bbbTrafficControl.adoc
+++ b/src/examples/bbbTrafficControl.adoc
@@ -3,7 +3,7 @@ title: "Run the controller of the traffic light example in the BeagleBoardBlack 
 url: doc/examples/bbbTrafficControl.html
 ---
 
-= [[topOfPage]]Run the controller of the traffic light example in the BeagleBoardBlack (BBB)
+= Run the controller of the traffic light example in the BeagleBoardBlack (BBB)
 :lang: en
 :imagesdir: img
 
@@ -139,4 +139,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/examples/examples.adoc
+++ b/src/examples/examples.adoc
@@ -3,7 +3,7 @@ title: "Examples"
 url: doc/examples/examples.html
 ---
 
-= [[topOfPage]]Eclipse 4diac Examples
+= Eclipse 4diac Examples
 :lang: en
 
 This page is intended to serve as index for 4diac examples that help understand and develop applications. 

--- a/src/examples/pidMotor.adoc
+++ b/src/examples/pidMotor.adoc
@@ -3,7 +3,7 @@ title: "Implement a PID Controller for the Position of an EV3 motor"
 url: doc/examples/pidMotor.html
 ---
 
-= [[topOfPage]] Implement a PID Controller for the Position of an EV3 motor
+=  Implement a PID Controller for the Position of an EV3 motor
 :lang: en
 :imagesdir: img
 
@@ -304,4 +304,4 @@ If you want to go back to the Start Here page, we leave you here a fast access
 
 xref:../doc_overview.adoc[Start Here page]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/examples/xplus3.adoc
+++ b/src/examples/xplus3.adoc
@@ -3,7 +3,7 @@ title: "X+3 Tutorial"
 url: doc/examples/xplus3.html
 ---
 
-= [[topOfPage]] X+3 Tutorial
+=  X+3 Tutorial
 :lang: en
 :imagesdir: img
 
@@ -157,4 +157,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/faq.adoc
+++ b/src/faq.adoc
@@ -3,7 +3,7 @@ title: "Eclipse 4diac FAQs"
 url: doc/faq.html
 ---
 
-= [[topOfPage]] Eclipse 4diac FAQs
+=  Eclipse 4diac FAQs
 
 == 4diac IDE FAQ
 
@@ -39,7 +39,7 @@ There are two possibilities to do that:
   By searching through the items you can reopen an accidentally closed view. 
   This option is especially of interest when you have a custom perspective layout you don't like to lose by resetting the perspective.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 === [[IDE_FAQ2]] Download not possible! Defined profile () for RMT_XXX.xxx not supported
 * Go to the System Configuration
@@ -47,7 +47,7 @@ link:#topOfPage[Go to top]
 * Change the properties [.menu4diac]#Dialog → Advanced → Misc → Profile#
 * Set Profile to HOLOBLOC
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ3]]When I download my application, I get an UNSUPPORTED TYPE error message in the [.view4diac]#Deployment Console#
@@ -57,14 +57,14 @@ This message appears for multiple problems:
 ** In 4diac IDE [.menu4diac]#Window → Preferences → 4diac IDE → FORTE Preferences# the path to your correct [.fileLocation]#forte.exe# has to be defined.
 ** Or start your [.fileLocation]#forte.exe# directly (development tool specific)
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ4]]When I download my application, I get a STATUS ACCESS VIOLATION error messages in the [.view4diac]#Deployment Console#
 Check if you used [.element4diac]#Composite Function Blocks# within your [.element4diac]#Application#. 
 Make sure that you have the source code (*.cpp, *.h) of all [.element4diac]#Function Blocks# within the [.element4diac]#Composite's Network#. Also check if all  source files are listed within a [.fileLocation]#CMakeLists.txt# file.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ5]]When I download my application, I get a Create FB Instance failed error
@@ -72,7 +72,7 @@ Verify that the interface of the Function Block you want to download is the same
 In case you download a Composite Function Block, please make sure that its Function Block Network matches the Function Block Network within your 4diac FORTE executable. 
 When in doubt, export your Function Block and compile 4diac FORTE before you download again.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ6]]When I want to download my application, I get a connection refused# message
@@ -82,27 +82,27 @@ Examine the following topics:
 * Check in Task Manager (Windows) if an "old" crashed 4diac FORTE blocks the port 
 * Check if Monitoring has been started before downloading (FORTE only supports a single connection at the management interface)
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ7]]How do I use ARRAYs?
 When you create a new Function Block, choose the desired type for your array elements in the [.menu4diac]#Type# drop down of the specific data and set the desired array size [.menu4diac]#ArraySize#. 
 For initializing, put the values in curly brackets (e.g., [.inlineCode]#\{1,2,3}#).
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ8]]What does [.command4diac]#CLEAN Device# do?
 [.command4diac]#CLEAN Device# deletes all existing [.element4diac]#Resources# and the FBs in the [.element4diac]#Resources#. 
 After [.command4diac]#CLEAN Device#, you can deploy any other FB Network.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[IDE_FAQ9]]What does [.command4diac]#KILL Device# do?
 [.command4diac]#KILL Devices# terminates 4diac FORTE.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 == 4diac FORTE answers
 
@@ -111,7 +111,7 @@ link:#topOfPage[Go to top]
   Maybe your system misses something.
 * Do you have spaces in the path to your 4diac FORTE? Some Cygwin versions have problems with these.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[fortefaq2]]CMake/Cygwin: Can not find C and C++ compilers
@@ -128,7 +128,7 @@ your C compiler: CMAKE_C_COMPILER-NOTFOUND was not found. Please set CMAKE_C_COM
 In this case, you need to tick the check box Advanced and look for [.specificText]#CMAKE_CXXX_COMPILER# and [.specificText]#CMAKE_C_COMPILER# and set the path and executable for your C and C++ compiler. 
 As an example, for Cygwin this could be [.fileLocation]#c:\cygwin\bin\g++-3.exe# for the C++ compiler and [.fileLocation]#c:\cygwin\bin\gcc-3.exe# for the C compiler.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[fortefaq3]]CMake/Cygwin: Can not find RC Compilers
@@ -142,7 +142,7 @@ your RC compiler: CMAKE_RC_COMPILER-NOTFOUND was not found. Please set
 Again you need to tick the check box Advanced and look for [.specificText]#CMAKE_RC_COMPILER#. 
 For Cygwin or MinGW on Windows, it needs a file called windres.exe (e.g., C:\cygwin\bin\windres.exe).
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 
 === [[fortefaq4]]FORTE is C++, why are you then using the C-style include files for the standard c library instead of the C++ style include files?
@@ -151,7 +151,7 @@ This especially applies to real-time OS such as eCos where you can freely config
 Using C++ style C include files on these platforms would pull lots of stuff from the compilers in and result in a bigger image or even worse it would not
 compile. So as to current experience, C style include files are more reliable.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 === [[fortefaq5]]Within my 4diac FORTE console, I get UDP-Socket Send failed: Network is unreachable
 Consider to explicitly set up multicast IP routing in the kernel with the [.inlineCode]#route# command. 
@@ -161,13 +161,13 @@ route add -net 224.0.0.0 netmask 240.0.0.0 dev eth0
 ----
 The IPs are the desired multicast IPs.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 === [[fortefaq6]]Within my 4diac FORTE console, I get connection closed by peer
 The TCP port is opened by a server in the RMT_RES. 
 This server handles the communication with the tool for download and monitoring. 
 The message indicates the end of the download process when 4diac IDE disconnects.
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 
 Or xref:./doc_overview.adoc[Go to the Start Here Page]

--- a/src/installation/bootWithForte.adoc
+++ b/src/installation/bootWithForte.adoc
@@ -3,7 +3,7 @@ title: "Start 4diac FORTE after boot on Linux based systems"
 url: doc/installation/bootWithForte.html
 ---
 
-= [[topOfPage]]Start 4diac FORTE after boot on Linux based systems
+= Start 4diac FORTE after boot on Linux based systems
 :lang: en
 
 Usually programmable logic controllers start their runtime directly after boot, that the user can either manually download the user defined control application without login at the programmable logic controller, or that a boot file which contains the user defined application is loaded when the runtime starts. 
@@ -99,4 +99,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/docker.adoc
+++ b/src/installation/docker.adoc
@@ -3,7 +3,7 @@ title: "Building 4diac FORTE Docker Images"
 url: doc/installation/docker.html
 ---
 
-= [[topOfPage]]Building 4diac FORTE Docker Images
+= Building 4diac FORTE Docker Images
 :lang: en
 
 
@@ -96,4 +96,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/eclipse.adoc
+++ b/src/installation/eclipse.adoc
@@ -3,7 +3,7 @@ title: "Compiling and Debugging 4diac FORTE with Eclipse"
 url: doc/installation/eclipse.html
 ---
 
-= [[topOfPage]]Compiling and Debugging 4diac FORTE with Eclipse
+= Compiling and Debugging 4diac FORTE with Eclipse
 :lang: en
 :imagesdir: img
 
@@ -80,4 +80,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/freeRTOSLwIP.adoc
+++ b/src/installation/freeRTOSLwIP.adoc
@@ -3,7 +3,7 @@ title: "Building 4diac FORTE for freeRTOS + LwIP"
 url: doc/installation/freeRTOSLwIP.html
 ---
 
-= [[topOfPage]]Building 4diac FORTE for freeRTOS + LwIP
+= Building 4diac FORTE for freeRTOS + LwIP
 :lang: en
 :imagesdir: img
 
@@ -163,4 +163,4 @@ access
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/installation.adoc
+++ b/src/installation/installation.adoc
@@ -3,7 +3,7 @@ title: "Installation"
 url: doc/installation/installation.html
 ---
 
-= [[topOfPage]]Installation
+= Installation
 :lang: en
 :imagesdir: img
 
@@ -244,4 +244,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/legoMindstormEv3.adoc
+++ b/src/installation/legoMindstormEv3.adoc
@@ -3,7 +3,7 @@ title: "Using Eclipse 4diac with a Lego Mindstorm EV3"
 url: doc/installation/legoMindstormEv3.html
 ---
 
-= [[topOfPage]]Using Eclipse 4diac with a Lego Mindstorm EV3
+= Using Eclipse 4diac with a Lego Mindstorm EV3
 :lang: en
 
 
@@ -158,4 +158,4 @@ access
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/minGW.adoc
+++ b/src/installation/minGW.adoc
@@ -3,7 +3,7 @@ title: "Setting up MinGW-w64"
 url: doc/installation/minGW.html
 ---
 
-= [[topOfPage]]Setting up MinGW-w64
+= Setting up MinGW-w64
 :lang: en
 
 == Install latest MinGW-w64 via MSYS2
@@ -75,4 +75,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/installation/pikeos_posix.adoc
+++ b/src/installation/pikeos_posix.adoc
@@ -3,7 +3,7 @@ title: "Setting up 4diac FORTE for Posix PikeOS 5.x"
 url: doc/installation/pikeos_posix.html
 ---
 
-= [[topOfPage]]Setting up 4diac FORTE for Posix PikeOS 5.x
+= Setting up 4diac FORTE for Posix PikeOS 5.x
 :lang: en
 :imagesdir: img
 
@@ -149,10 +149,10 @@ Repeat this procedure for `POSIX Process`.
 
 [Cols="1,1,1,1"]
 |===
-| Key | Value | Example for QEMU with Usermode NW | Example for QEMU with TUN/TAP NW |
+| Key | Value | Example for QEMU with Usermode NW | Example for QEMU with TUN/TAP NW 
 
-|Interface Address | e.g. "POSIX Process" +1 | 10.0.2.17 | 192.168.0.4
-|Netmask | 255.x.x.x | 255.255.255.0 | 255.255.255.0
+|Interface Address | e.g. "POSIX Process" +1 | 10.0.2.17 | 192.168.0.4 
+|Netmask | 255.x.x.x | 255.255.255.0 | 255.255.255.0 
 |Gateway address | Gateway in target NW to reach the host | 10.0.2.2 | 192.168.0.1
 |===
 

--- a/src/installation/raspi.adoc
+++ b/src/installation/raspi.adoc
@@ -3,7 +3,7 @@ title: "Building 4diac FORTE on Raspberry Pi"
 url: doc/installation/raspi.html
 ---
 
-= [[topOfPage]]Building 4diac FORTE on Raspberry Pi
+= Building 4diac FORTE on Raspberry Pi
 :lang: en
 :imagesdir: img
 
@@ -187,4 +187,4 @@ If you want to go back to the Start Here page, we leave you here a fast access
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/visualStudio.adoc
+++ b/src/installation/visualStudio.adoc
@@ -3,7 +3,7 @@ title: "Compiling and Debugging 4diac FORTE with MS Visual Studio"
 url: doc/installation/visualStudio.html
 ---
 
-= [[topOfPage]]Compiling and Debugging 4diac FORTE with MS Visual Studio
+= Compiling and Debugging 4diac FORTE with MS Visual Studio
 :lang: en
 :imagesdir: img
 
@@ -65,4 +65,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/visualStudioCode.adoc
+++ b/src/installation/visualStudioCode.adoc
@@ -3,7 +3,7 @@ title: "Compiling and Debugging 4diac FORTE with MS Visual Studio Code"
 url: doc/installation/visualStudioCode.html
 ---
 
-= [[topOfPage]]Compiling and Debugging 4diac FORTE with MS Visual Studio Code
+= Compiling and Debugging 4diac FORTE with MS Visual Studio Code
 :lang: en
 :imagesdir: img
 
@@ -76,4 +76,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/installation/wago.adoc
+++ b/src/installation/wago.adoc
@@ -3,7 +3,7 @@ title: "Building 4diac FORTE for Wago"
 url: doc/installation/wago.html
 ---
 
-= [[topOfPage]]Building 4diac FORTE for Wago
+= Building 4diac FORTE for Wago
 :lang: en
 :imagesdir: img
 
@@ -179,4 +179,4 @@ access
 
 xref:../doc_overview.adoc[Start Here page]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/intro/4diacFramework.adoc
+++ b/src/intro/4diacFramework.adoc
@@ -3,7 +3,7 @@ title: "The Eclipse 4diac Project"
 url: doc/intro/4diacframework.html
 ---
 
-= [[topOfPage]]The Eclipse 4diac Project
+= The Eclipse 4diac Project
 :lang: en
 :imagesdir: img
 
@@ -75,4 +75,4 @@ xref:../installation/installation.adoc[Installation]
 * If you want to go back to the Where to Start page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/intro/iec61499.adoc
+++ b/src/intro/iec61499.adoc
@@ -3,7 +3,7 @@ title: "IEC 61499 101"
 url: doc/intro/iec61499.html
 ---
 
-= [[topOfPage]]IEC 61499 101
+= IEC 61499 101
 :lang: en
 :imagesdir: ./img
 
@@ -244,4 +244,4 @@ xref:4diacFramework.adoc[Eclipse 4diac Framework]
 * In case you'd like to return to the "Where to Start"-page, we leave here a fast access for you: +
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/EV3.adoc
+++ b/src/io_config/EV3.adoc
@@ -328,4 +328,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/Odroid.adoc
+++ b/src/io_config/Odroid.adoc
@@ -28,4 +28,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/PiFace.adoc
+++ b/src/io_config/PiFace.adoc
@@ -25,4 +25,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/RevolutionPi.adoc
+++ b/src/io_config/RevolutionPi.adoc
@@ -87,4 +87,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/SysFs.adoc
+++ b/src/io_config/SysFs.adoc
@@ -36,4 +36,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/Wago.adoc
+++ b/src/io_config/Wago.adoc
@@ -183,4 +183,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../index.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/io_config.adoc
+++ b/src/io_config/io_config.adoc
@@ -3,7 +3,7 @@ title: "I/O Configuration for Different Platforms"
 url: doc/io_config/io_config.html
 ---
 
-= [[topOfPage]]I/O Configuration for Different Platforms
+= I/O Configuration for Different Platforms
 :lang: en
 
 Using QX, IX and similar allows you to access the inputs and outputs of a supported hardware. 
@@ -57,4 +57,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/mlpi.adoc
+++ b/src/io_config/mlpi.adoc
@@ -33,4 +33,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/plc01a1.adoc
+++ b/src/io_config/plc01a1.adoc
@@ -179,4 +179,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/io_config/uMIC.adoc
+++ b/src/io_config/uMIC.adoc
@@ -83,4 +83,4 @@ If you want to go back to the Where to Start page, we leave you here a fast acce
 
 xref:../doc_overview.adoc[Where to Start]
 
-Or link:#topOfPage[Go to top]
+Or link:#top[Go to top]

--- a/src/tutorials/advancedFeatures.adoc
+++ b/src/tutorials/advancedFeatures.adoc
@@ -3,7 +3,7 @@ title: "Step 6 - Advanced Features"
 url: doc/tutorials/advancedFeatures.html
 ---
 
-= [[topOfPage]]Step 6 - Advanced Features
+= Step 6 - Advanced Features
 :lang: en
 :imagesdir: img
 
@@ -85,4 +85,4 @@ xref:./otherUseful.adoc[Step 5 - Other Basic Features]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc#wheretostart[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/tutorials/createOwnTypes.adoc
+++ b/src/tutorials/createOwnTypes.adoc
@@ -3,7 +3,7 @@ title: "Step 4 - Create Your own Function Block Types"
 url: doc/tutorials/createOwnTypes.html
 ---
 
-= [[topOfPage]]Step 4 - Create Your own Function Block Types
+= Step 4 - Create Your own Function Block Types
 :lang: en
 :imagesdir: img
 
@@ -294,4 +294,4 @@ xref:./use4diacRemotely.adoc[Step 3 - Deploy Applications Remotely]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/tutorials/distribute4diac.adoc
+++ b/src/tutorials/distribute4diac.adoc
@@ -3,7 +3,7 @@ title: "Step 2 - Distribute 4diac Applications"
 url: doc/tutorials/distribute4diac.html
 ---
 
-= [[topOfPage]]Step 2 - Distribute 4diac Applications
+= Step 2 - Distribute 4diac Applications
 :lang: en
 :imagesdir: img
 
@@ -137,4 +137,4 @@ link:./use4diacLocally.adoc[Step 1 - Use 4diac Locally (Blinking Tutorial)]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/tutorials/dynamicTypeLoader.adoc
+++ b/src/tutorials/dynamicTypeLoader.adoc
@@ -3,7 +3,7 @@ title: "Step 7 - Deploying new FBs with the Dynamic Type Loader"
 url: doc/tutorials/dynamicTypeLoader.html
 ---
 
-= [[topOfPage]]Step 7 - Deploying new FBs with the Dynamic Type Loader
+= Step 7 - Deploying new FBs with the Dynamic Type Loader
 :lang: en
 :imagesdir: img
 
@@ -101,5 +101,5 @@ Everything should be set up and you can deploy your FBs, like you learned earlie
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc#wheretostart[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]
 

--- a/src/tutorials/otherUseful.adoc
+++ b/src/tutorials/otherUseful.adoc
@@ -79,4 +79,4 @@ xref:./createOwnTypes.adoc[Step 4 - Create Your own Function Block Types]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/tutorials/overview.adoc
+++ b/src/tutorials/overview.adoc
@@ -3,7 +3,7 @@ title: "Step 0 - 4diac IDE - Overview"
 url: doc/tutorials/overview.html
 ---
 
-= [[topOfPage]] Step 0 - 4diac IDE - Overview
+=  Step 0 - 4diac IDE - Overview
 :lang: en
 :imagesdir: img
 
@@ -155,4 +155,4 @@ xref:use4diacLocally.adoc[Step 1 - Use 4diac IDE Locally]
 * If you want to go back to the Start Here page, we leave you here a fast access: +
 xref:../doc_overview.adoc[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/tutorials/use4diacLocally.adoc
+++ b/src/tutorials/use4diacLocally.adoc
@@ -3,7 +3,7 @@ title: "Step 1 - Use 4diac Locally"
 url: doc/tutorials/use4diacLocally.html
 ---
 
-= [[topOfPage]]Step 1 - Use 4diac Locally
+= Step 1 - Use 4diac Locally
 :lang: en
 :imagesdir: img
 
@@ -291,4 +291,4 @@ xref:./overview.adoc[Step 0 - 4diac IDE Overview] +
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]

--- a/src/tutorials/use4diacRemotely.adoc
+++ b/src/tutorials/use4diacRemotely.adoc
@@ -3,7 +3,7 @@ title: "Step 3 - Deploy Applications Remotely"
 url: doc/tutorials/use4diacRemotely.html
 ---
 
-= [[topOfPage]]Step 3 - Deploy Applications Remotely
+= Step 3 - Deploy Applications Remotely
 :lang: en
 :imagesdir: img
 
@@ -108,4 +108,4 @@ xref:./distribute4diac.adoc[Step 2 - Distribute 4diac Applications]
 * If you want to go back to the Start Here page, we leave you here a fast access +
 xref:../doc_overview.adoc[Where to Start]
 
-link:#topOfPage[Go to top]
+link:#top[Go to top]


### PR DESCRIPTION
In order to make the documentation more universally usable the topOfPage anchors are removed and links to them replaced by top.

Fixes: https://github.com/eclipse-4diac/4diac-documentation/issues/65