### PR TITLE
docs: Add macOS UI test requirement to build instructions

### DIFF
--- a/src/development/building4diac.adoc
+++ b/src/development/building4diac.adoc
@@ -156,7 +156,9 @@ Then the necessary steps for generating binary 4diac IDE packages are:
 . Invoke the [.menu4diac]#Run As → Maven Install#.
 . After a successful build you will find the output in `plugins/org.eclipse.fordiac.ide.product/target/products` directory.
 
-Alternatively you can run `.mvn .install`  on the command line in the root folder of 4diac IDE source code.
+Alternatively you can run `mvn clean install` on the command line in the root folder of 4diac IDE source code.
+
+NOTE: When running UI tests directly from an IDE (e.g. Eclipse) on macOS, you must manually add `-XstartOnFirstThread` to your JVM arguments. This is handled automatically by a Maven profile when building from the command line.
 
 == Where to go from here?
 


### PR DESCRIPTION
**Description**: As requested by the maintainers in eclipse-4diac/4diac-ide#2423, this PR adds a quick note to the build documentation regarding macOS / Apple Silicon environments. When running UI tests on macOS directly from an IDE, the JVM requires the -XstartOnFirstThread argument to prevent SWTException crashes. While this has been automated in the main repo's pom.xml via a Maven profile for CLI builds, developers using the Eclipse IDE runner manually need to be aware of this requirement.

**Related PR**: eclipse-4diac/4diac-ide#2423