### PR TITLE
First version of an DataType XSD for 4diac IDE XML files

### DIFF
--- a/src/specs/xsds/attributedeclaration.xsd
+++ b/src/specs/xsds/attributedeclaration.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Johannes Kepler University Linz
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+    Alois Zoitl - initial API and implementation and/or initial documentation
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:include schemaLocation="datatype.xsd"/>
+
+<xs:element name="AttributeDeclaration">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="LibraryElement">
+        <xs:sequence>
+          <xs:choice>
+            <xs:element ref="DirectlyDerivedType"/>
+            <xs:element ref="EnumeratedType"/>
+            <xs:element ref="SubrangeType"/>
+            <xs:element ref="ArrayType"/>
+            <xs:element ref="StructuredType"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+
+</xs:schema>

--- a/src/specs/xsds/common.xsd
+++ b/src/specs/xsds/common.xsd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Johannes Kepler University Linz
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+    Alois Zoitl - initial API and implementation and/or initial documentation
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:simpleType name="Identifier">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[_a-zA-Z][a-zA-Z0-9]+(_[a-zA-Z0-9]+)*|[_a-zA-Z]"/>
+  </xs:restriction>
+</xs:simpleType>
+
+
+<xs:simpleType name="PackageName">
+  <xs:restriction base="xs:string">
+    <!-- Regex from Identifier needs to be duplicated as XSD can not refer to it -->
+    <xs:pattern value="([_a-zA-Z][a-zA-Z0-9]+(_[a-zA-Z0-9]+)*|[_a-zA-Z])(::([_a-zA-Z][a-zA-Z0-9]+(_[a-zA-Z0-9]+)*|[_a-zA-Z]))*"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="ImportDeclaration">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([_a-zA-Z][a-zA-Z0-9]+(_[a-zA-Z0-9]+)*|[_a-zA-Z])(::([_a-zA-Z][a-zA-Z0-9]+(_[a-zA-Z0-9]+)*|[_a-zA-Z]))*(::\*)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+
+<xs:element name="LibraryElement" type="LibraryElement"/>
+<xs:complexType name="LibraryElement">
+  <xs:sequence>
+    <xs:element ref="Identification"  minOccurs="0"/>
+    <xs:element ref="VersionInfo"     minOccurs="1" maxOccurs="unbounded"/>
+    <xs:element ref="CompilerInfo"    minOccurs="0"/>
+    <xs:element ref="Attribute"       minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute name="Name"    type="Identifier" use="required"/>
+  <xs:attribute name="Comment" type="xs:string"  use="optional"/>
+</xs:complexType>
+
+<xs:element name="Identification">
+  <xs:complexType>
+    <xs:attribute name="Standard"          type="xs:string" use="optional"/>
+    <xs:attribute name="Classification"    type="xs:string" use="optional"/>
+    <xs:attribute name="ApplicationDomain" type="xs:string" use="optional"/>
+    <xs:attribute name="Function"          type="xs:string" use="optional"/>
+    <xs:attribute name="Type"              type="xs:string" use="optional"/>
+    <xs:attribute name="Description"       type="xs:string" use="optional"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="VersionInfo">
+  <xs:complexType>
+    <xs:attribute name="Organization" type="xs:string"        use="required"/>
+    <xs:attribute name="Version"      type="VersionValueType" use="required"/>
+    <xs:attribute name="Author"       type="xs:string"        use="required"/>
+    <xs:attribute name="Date"         type="xs:string"        use="required"/>
+    <xs:attribute name="Remarks"      type="xs:string"        use="optional"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="CompilerInfo">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element ref="Import"  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="packageName" type="PackageName" use="optional"/>
+    <xs:attribute name="header"      type="xs:string"   use="optional"/>
+    <xs:attribute name="classdef"    type="xs:string"   use="optional"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="Import">
+  <xs:complexType>
+    <xs:attribute name="declaration" type="ImportDeclaration" use="required"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:simpleType name="VersionValueType">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-9]{1,2}\.[0-9]{1,2}[a-zA-Z]?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+
+<xs:element name="Attribute">
+  <xs:complexType>
+   <xs:attribute name="Name"    type="Identifier"  use="required"/>
+   <xs:attribute name="Value"   type="xs:string"   use="required"/>
+   <xs:attribute name="Type"    type="PackageName" use="optional"/>
+   <xs:attribute name="Comment" type="xs:string"   use="optional"/>
+  </xs:complexType>
+ </xs:element>
+
+</xs:schema>

--- a/src/specs/xsds/common.xsd
+++ b/src/specs/xsds/common.xsd
@@ -34,55 +34,46 @@
 </xs:simpleType>
 
 
-<xs:element name="LibraryElement" type="LibraryElement"/>
-<xs:complexType name="LibraryElement">
+<xs:complexType name="LibraryElement"  abstract="true">
   <xs:sequence>
-    <xs:element ref="Identification"  minOccurs="0"/>
-    <xs:element ref="VersionInfo"     minOccurs="1" maxOccurs="unbounded"/>
-    <xs:element ref="CompilerInfo"    minOccurs="0"/>
-    <xs:element ref="Attribute"       minOccurs="0"/>
+    <xs:element name="Identification" type="Identification" minOccurs="0"/>
+    <xs:element name="VersionInfo"    type="VersionInfo"    minOccurs="1" maxOccurs="unbounded"/>
+    <xs:element name="CompilerInfo"   type="CompilerInfo"   minOccurs="0"/>
+    <xs:group ref="AttributeGroup"/>
   </xs:sequence>
   <xs:attribute name="Name"    type="Identifier" use="required"/>
   <xs:attribute name="Comment" type="xs:string"  use="optional"/>
 </xs:complexType>
 
-<xs:element name="Identification">
-  <xs:complexType>
-    <xs:attribute name="Standard"          type="xs:string" use="optional"/>
-    <xs:attribute name="Classification"    type="xs:string" use="optional"/>
-    <xs:attribute name="ApplicationDomain" type="xs:string" use="optional"/>
-    <xs:attribute name="Function"          type="xs:string" use="optional"/>
-    <xs:attribute name="Type"              type="xs:string" use="optional"/>
-    <xs:attribute name="Description"       type="xs:string" use="optional"/>
-  </xs:complexType>
-</xs:element>
+<xs:complexType name="Identification">
+  <xs:attribute name="Standard"          type="xs:string" use="optional"/>
+  <xs:attribute name="Classification"    type="xs:string" use="optional"/>
+  <xs:attribute name="ApplicationDomain" type="xs:string" use="optional"/>
+  <xs:attribute name="Function"          type="xs:string" use="optional"/>
+  <xs:attribute name="Type"              type="xs:string" use="optional"/>
+  <xs:attribute name="Description"       type="xs:string" use="optional"/>
+</xs:complexType>
 
-<xs:element name="VersionInfo">
-  <xs:complexType>
-    <xs:attribute name="Organization" type="xs:string"        use="required"/>
-    <xs:attribute name="Version"      type="VersionValueType" use="required"/>
-    <xs:attribute name="Author"       type="xs:string"        use="required"/>
-    <xs:attribute name="Date"         type="xs:string"        use="required"/>
-    <xs:attribute name="Remarks"      type="xs:string"        use="optional"/>
-  </xs:complexType>
-</xs:element>
+<xs:complexType name="VersionInfo">
+  <xs:attribute name="Organization" type="xs:string"        use="required"/>
+  <xs:attribute name="Version"      type="VersionValueType" use="required"/>
+  <xs:attribute name="Author"       type="xs:string"        use="required"/>
+  <xs:attribute name="Date"         type="xs:string"        use="required"/>
+  <xs:attribute name="Remarks"      type="xs:string"        use="optional"/>
+</xs:complexType>
 
-<xs:element name="CompilerInfo">
-  <xs:complexType>
-    <xs:sequence>
-      <xs:element ref="Import"  minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-    <xs:attribute name="packageName" type="PackageName" use="optional"/>
-    <xs:attribute name="header"      type="xs:string"   use="optional"/>
-    <xs:attribute name="classdef"    type="xs:string"   use="optional"/>
-  </xs:complexType>
-</xs:element>
+<xs:complexType name="CompilerInfo">
+  <xs:sequence>
+    <xs:element name="Import" type="Import"  minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="packageName" type="PackageName" use="optional"/>
+  <xs:attribute name="header"      type="xs:string"   use="optional"/>
+  <xs:attribute name="classdef"    type="xs:string"   use="optional"/>
+</xs:complexType>
 
-<xs:element name="Import">
-  <xs:complexType>
-    <xs:attribute name="declaration" type="ImportDeclaration" use="required"/>
-  </xs:complexType>
-</xs:element>
+<xs:complexType name="Import">
+  <xs:attribute name="declaration" type="ImportDeclaration" use="required"/>
+</xs:complexType>
 
 <xs:simpleType name="VersionValueType">
   <xs:restriction base="xs:string">
@@ -90,14 +81,17 @@
   </xs:restriction>
 </xs:simpleType>
 
+<xs:complexType name="Attribute">
+  <xs:attribute name="Name"    type="Identifier"  use="required"/>
+  <xs:attribute name="Value"   type="xs:string"   use="required"/>
+  <xs:attribute name="Type"    type="PackageName" use="optional"/>
+  <xs:attribute name="Comment" type="xs:string"   use="optional"/>
+</xs:complexType>
 
-<xs:element name="Attribute">
-  <xs:complexType>
-   <xs:attribute name="Name"    type="Identifier"  use="required"/>
-   <xs:attribute name="Value"   type="xs:string"   use="required"/>
-   <xs:attribute name="Type"    type="PackageName" use="optional"/>
-   <xs:attribute name="Comment" type="xs:string"   use="optional"/>
-  </xs:complexType>
- </xs:element>
+<xs:group name="AttributeGroup">
+  <xs:sequence>
+    <xs:element name="Attribute" type="Attribute" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:group>
 
 </xs:schema>

--- a/src/specs/xsds/datatype.xsd
+++ b/src/specs/xsds/datatype.xsd
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Johannes Kepler University Linz
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+    Alois Zoitl - initial API and implementation and/or initial documentation
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:include schemaLocation="common.xsd"/>
+
+<xs:element name="DataType">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="LibraryElement">
+        <xs:sequence>
+          <xs:choice>
+            <xs:element ref="DirectlyDerivedType"/>
+            <xs:element ref="EnumeratedType"/>
+            <xs:element ref="SubrangeType"/>
+            <xs:element ref="ArrayType"/>
+            <xs:element ref="StructuredType"/>
+          </xs:choice>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="UserDefinedDataType" type="UserDefinedDataType"/>
+<xs:complexType name="UserDefinedDataType">
+  <xs:attribute name="InitialValue" type="xs:string" use="optional"/>
+  <xs:attribute name="Comment"      type="xs:string" use="optional"/>
+</xs:complexType>
+
+<xs:element name="DirectlyDerivedType" type="DirectlyDerivedType"/>
+<xs:complexType name="DirectlyDerivedType">
+  <xs:complexContent>
+    <xs:extension base="UserDefinedDataType">
+        <xs:attribute name="BaseType" type="PackageName" use="required"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:element name="EnumeratedType" type="EnumeratedType"/>
+<xs:complexType name="EnumeratedType">
+  <xs:complexContent>
+    <xs:extension base="UserDefinedDataType">
+      <xs:sequence>
+        <xs:element ref="EnumeratedValue" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:element name="SubrangeType" type="SubrangeType"/>
+<xs:complexType name="SubrangeType">
+  <xs:complexContent>
+    <xs:extension base="UserDefinedDataType">
+      <xs:sequence>
+        <xs:element ref="Subrange"/>
+      </xs:sequence>
+      <xs:attribute name="BaseType" type="SubrangeBaseType" use="required"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:element name="ArrayType" type="ArrayType"/>
+<xs:complexType name="ArrayType">
+  <xs:complexContent>
+    <xs:extension base="UserDefinedDataType">
+      <xs:sequence>
+        <xs:element ref="Subrange" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="BaseType" type="PackageName" use="required"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:element name="StructuredType" type="StructuredType"/>
+<xs:complexType name="StructuredType">
+  <xs:choice maxOccurs="unbounded">
+   <xs:element ref="VarDeclaration"/>
+   <xs:element ref="SubrangeVarDeclaration"/>
+  </xs:choice>
+  <xs:attribute name="Comment" type="xs:string" use="optional"/>
+</xs:complexType>
+
+<xs:element name="EnumeratedValue" type="EnumeratedValue"/>
+<xs:complexType name="EnumeratedValue">
+  <xs:attribute name="Name"    type="Identifier" use="optional"/>
+  <xs:attribute name="Comment" type="xs:string"  use="optional"/>
+</xs:complexType>
+
+<xs:element name="Subrange" type="Subrange"/>
+<xs:complexType name="Subrange">
+  <xs:attribute name="LowerLimit" type="xs:integer" use="required"/>
+  <xs:attribute name="UpperLimit" type="xs:integer" use="required"/>
+</xs:complexType>
+
+<xs:element name="VarDeclaration" type="VarDeclaration"/>
+<xs:complexType name="VarDeclaration">
+  <xs:attribute name="Name"         type="Identifier"  use="required"/>
+  <xs:attribute name="Type"         type="PackageName" use="required"/>
+  <xs:attribute name="ArraySize"    type="xs:string"   use="optional"/>
+  <xs:attribute name="InitialValue" type="xs:string"   use="optional"/>
+  <xs:attribute name="Comment"      type="xs:string"   use="optional"/>
+</xs:complexType>
+
+
+<xs:element name="SubrangeVarDeclaration" type="SubrangeVarDeclaration"/>
+<xs:complexType name="SubrangeVarDeclaration">
+  <xs:complexContent>
+    <xs:extension base="UserDefinedDataType">
+      <xs:sequence>
+        <xs:element ref="Subrange"  maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="Name" type="Identifier"       use="required"/>
+      <xs:attribute name="Type" type="SubrangeBaseType" use="required"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+
+<xs:simpleType name="SubrangeBaseType">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="SINT"/>
+    <xs:enumeration value="INT"/>
+    <xs:enumeration value="DINT"/>
+    <xs:enumeration value="LINT"/>
+    <xs:enumeration value="USINT"/>
+    <xs:enumeration value="UINT"/>
+    <xs:enumeration value="UDINT"/>
+    <xs:enumeration value="ULINT"/>
+  </xs:restriction>
+</xs:simpleType>
+
+</xs:schema>

--- a/src/specs/xsds/datatype.xsd
+++ b/src/specs/xsds/datatype.xsd
@@ -34,8 +34,7 @@
   </xs:complexType>
 </xs:element>
 
-<xs:element name="UserDefinedDataType" type="UserDefinedDataType"/>
-<xs:complexType name="UserDefinedDataType">
+<xs:complexType name="UserDefinedDataType"  abstract="true">
   <xs:attribute name="InitialValue" type="xs:string" use="optional"/>
   <xs:attribute name="Comment"      type="xs:string" use="optional"/>
 </xs:complexType>
@@ -54,7 +53,7 @@
   <xs:complexContent>
     <xs:extension base="UserDefinedDataType">
       <xs:sequence>
-        <xs:element ref="EnumeratedValue" maxOccurs="unbounded"/>
+        <xs:element name="EnumeratedValue" type="EnumeratedValue" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:extension>
   </xs:complexContent>
@@ -65,7 +64,7 @@
   <xs:complexContent>
     <xs:extension base="UserDefinedDataType">
       <xs:sequence>
-        <xs:element ref="Subrange"/>
+        <xs:element name="Subrange" type="Subrange"/>
       </xs:sequence>
       <xs:attribute name="BaseType" type="SubrangeBaseType" use="required"/>
     </xs:extension>
@@ -77,7 +76,7 @@
   <xs:complexContent>
     <xs:extension base="UserDefinedDataType">
       <xs:sequence>
-        <xs:element ref="Subrange" maxOccurs="unbounded"/>
+        <xs:element name="Subrange" type="Subrange" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="BaseType" type="PackageName" use="required"/>
     </xs:extension>
@@ -93,13 +92,11 @@
   <xs:attribute name="Comment" type="xs:string" use="optional"/>
 </xs:complexType>
 
-<xs:element name="EnumeratedValue" type="EnumeratedValue"/>
 <xs:complexType name="EnumeratedValue">
   <xs:attribute name="Name"    type="Identifier" use="optional"/>
   <xs:attribute name="Comment" type="xs:string"  use="optional"/>
 </xs:complexType>
 
-<xs:element name="Subrange" type="Subrange"/>
 <xs:complexType name="Subrange">
   <xs:attribute name="LowerLimit" type="xs:integer" use="required"/>
   <xs:attribute name="UpperLimit" type="xs:integer" use="required"/>
@@ -120,7 +117,7 @@
   <xs:complexContent>
     <xs:extension base="UserDefinedDataType">
       <xs:sequence>
-        <xs:element ref="Subrange"  maxOccurs="unbounded"/>
+        <xs:element name="Subrange" type="Subrange" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="Name" type="Identifier"       use="required"/>
       <xs:attribute name="Type" type="SubrangeBaseType" use="required"/>


### PR DESCRIPTION
This is a first attempt to start with a set of XSD files describing the IEC 61499 XML file format used by 4diac IDE. 

The files are developed from hand and from scratch utilizing XSD attributes and inheritance. The first for better describing the semantic values of attributes the later to reduce duplicated code. 

The goal of this development is to have the basis for an Eclipse 4diac portability compliance profile.

FYI @franz-hoepfinger-4diac.