### PR TITLE
Added XSD for Adapter Types

### DIFF
--- a/src/specs/xsds/adaptertype.xsd
+++ b/src/specs/xsds/adaptertype.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Johannes Kepler University Linz
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+    Alois Zoitl - initial API and implementation and/or initial documentation
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:include schemaLocation="block-common.xsd"/>
+
+<xs:element name="AdapterType">
+  <xs:complexType>
+    <xs:complexContent>
+      <xs:extension base="LibraryElement">
+        <xs:sequence>
+          <xs:element name="InterfaceList" type="InterfaceList"/>
+          <xs:element name="Service"       type="Service" minOccurs="0"/>
+          <xs:group ref="AttributeGroup"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:element>
+
+
+
+</xs:schema>

--- a/src/specs/xsds/block-common.xsd
+++ b/src/specs/xsds/block-common.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Johannes Kepler University Linz
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+    Alois Zoitl - initial API and implementation and/or initial documentation
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:include schemaLocation="datatype.xsd"/>
+
+<!-- ============================================== -->
+<!-- FB Interface                                   -->
+<!-- ============================================== -->
+<xs:complexType name="InterfaceList">
+  <xs:sequence>
+    <xs:element name="EventInputs"  type="EventInputs"  minOccurs="0" maxOccurs="1"/>
+    <xs:element name="EventOutputs" type="EventOutputs" minOccurs="0" maxOccurs="1"/>
+    <xs:element name="InputVars"    type="InputVars"    minOccurs="0" maxOccurs="1"/>
+    <xs:element name="OutputVars"   type="OutputVars"   minOccurs="0" maxOccurs="1"/>
+    <xs:element name="InOutVars"    type="InOutVars"    minOccurs="0" maxOccurs="1"/>
+    <xs:element name="Sockets"      type="Sockets"      minOccurs="0" maxOccurs="1"/>
+    <xs:element name="Plugs"        type="Plugs"        minOccurs="0" maxOccurs="1"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="EventInputs">
+  <xs:sequence>
+    <xs:element name="Event" type="Event" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="EventOutputs">
+  <xs:sequence>
+    <xs:element name="Event" type="Event" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="InputVars">
+  <xs:sequence>
+    <xs:element ref="VarDeclaration" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="OutputVars">
+  <xs:sequence>
+    <xs:element ref="VarDeclaration" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="InOutVars">
+  <xs:sequence>
+    <xs:element ref="VarDeclaration" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="Sockets">
+  <xs:sequence>
+    <xs:element name="AdapterDeclaration" type="AdapterDeclaration" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="Plugs">
+  <xs:sequence>
+    <xs:element name="AdapterDeclaration" type="AdapterDeclaration" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="Event">
+  <xs:sequence>
+    <xs:element name="With" type="With" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="NameTypeCommentAttributes"/>
+</xs:complexType>
+
+<xs:complexType name="With">
+  <xs:attribute name="Var" type="Identifier" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="AdapterDeclaration">
+  <xs:sequence>
+    <xs:element name="Parameter" type="Parameter" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="NameTypeCommentAttributes"/>
+  <xs:attributeGroup ref="PositionAttributes"/>
+</xs:complexType>
+
+<xs:complexType name="Parameter">
+  <xs:attributeGroup ref="NameCommentAttributes"/>
+  <xs:attribute name="Value" type="xs:string" use="required"/>
+</xs:complexType>
+
+
+<!-- ============================================== -->
+<!-- Service Sequence Diagram                       -->
+<!-- ============================================== -->
+<xs:complexType name="Service">
+  <xs:sequence>
+    <xs:element name="ServiceSequence" type="ServiceSequence" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="RightInterface" type="xs:string" use="required"/>
+  <xs:attribute name="LeftInterface"  type="xs:string" use="required"/>
+  <xs:attribute name="Comment"        type="xs:string" use="optional"/>
+</xs:complexType>
+
+<xs:complexType name="ServiceSequence">
+  <xs:sequence>
+    <xs:element name="ServiceTransaction" type="ServiceTransaction" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attributeGroup ref="NameCommentAttributes"/>
+</xs:complexType>
+
+<xs:complexType name="ServiceTransaction">
+  <xs:sequence>
+    <xs:element name="InputPrimitive"  type="InputPrimitive"  minOccurs="0" maxOccurs="1"/>
+    <xs:element name="OutputPrimitive" type="OutputPrimitive" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="InputPrimitive">
+  <xs:attributeGroup ref="ServicePrimitiveGroup"/>
+</xs:complexType>
+
+<xs:complexType name="OutputPrimitive">
+  <xs:attributeGroup ref="ServicePrimitiveGroup"/>
+</xs:complexType>
+
+<xs:attributeGroup name="ServicePrimitiveGroup">
+  <xs:attribute name="Interface"  type="xs:string" use="required"/>
+  <xs:attribute name="Event"      type="xs:string" use="required"/>
+  <xs:attribute name="Parameters" type="xs:string" use="optional"/>
+</xs:attributeGroup>
+
+</xs:schema>

--- a/src/specs/xsds/common.xsd
+++ b/src/specs/xsds/common.xsd
@@ -39,10 +39,8 @@
     <xs:element name="Identification" type="Identification" minOccurs="0"/>
     <xs:element name="VersionInfo"    type="VersionInfo"    minOccurs="1" maxOccurs="unbounded"/>
     <xs:element name="CompilerInfo"   type="CompilerInfo"   minOccurs="0"/>
-    <xs:group ref="AttributeGroup"/>
   </xs:sequence>
-  <xs:attribute name="Name"    type="Identifier" use="required"/>
-  <xs:attribute name="Comment" type="xs:string"  use="optional"/>
+  <xs:attributeGroup ref="NameCommentAttributes"/>
 </xs:complexType>
 
 <xs:complexType name="Identification">
@@ -81,11 +79,15 @@
   </xs:restriction>
 </xs:simpleType>
 
-<xs:complexType name="Attribute">
-  <xs:attribute name="Name"    type="Identifier"  use="required"/>
-  <xs:attribute name="Value"   type="xs:string"   use="required"/>
-  <xs:attribute name="Type"    type="PackageName" use="optional"/>
-  <xs:attribute name="Comment" type="xs:string"   use="optional"/>
+<xs:complexType name='Attribute'>
+  <xs:simpleContent>
+    <xs:extension base="xs:string">  <!-- Attributes with Type="CDATA" may have string content instead of value -->
+      <xs:attribute name="Name"    type="PackageName" use="required"/> <!-- For references to attribute declarations full qualified type name may be used -->
+      <xs:attribute name="Type"    type="PackageName" use="optional"/> <!-- For references to attribute declarations type may be omitted -->
+      <xs:attribute name='Value'   type='xs:string'   use='optional'/> <!-- Only optional for attributes with Type="CDATA" and string child content -->
+      <xs:attribute name="Comment" type="xs:string"   use="optional"/>
+    </xs:extension>
+  </xs:simpleContent>
 </xs:complexType>
 
 <xs:group name="AttributeGroup">
@@ -93,5 +95,26 @@
     <xs:element name="Attribute" type="Attribute" minOccurs="0" maxOccurs="unbounded"/>
   </xs:sequence>
 </xs:group>
+
+<xs:attributeGroup name="NameCommentAttributes">
+  <xs:attribute name="Name"    type="Identifier" use="required"/>
+  <xs:attribute name="Comment" type="xs:string"  use="optional"/>
+</xs:attributeGroup>
+
+<xs:attributeGroup name="NameTypeCommentAttributes">
+  <xs:attribute name="Type" type="PackageName" use="required"/>
+  <xs:attributeGroup ref="NameCommentAttributes"/>
+</xs:attributeGroup>
+
+<xs:simpleType name="Coordinate">
+  <xs:restriction base="xs:decimal">
+    <xs:fractionDigits value="2"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:attributeGroup name="PositionAttributes">
+  <xs:attribute name="x" type="Coordinate" use="optional"/>
+  <xs:attribute name="y" type="Coordinate" use="optional"/>
+</xs:attributeGroup>
 
 </xs:schema>

--- a/src/specs/xsds/datatype.xsd
+++ b/src/specs/xsds/datatype.xsd
@@ -28,6 +28,7 @@
             <xs:element ref="ArrayType"/>
             <xs:element ref="StructuredType"/>
           </xs:choice>
+          <xs:group ref="AttributeGroup"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -93,8 +94,7 @@
 </xs:complexType>
 
 <xs:complexType name="EnumeratedValue">
-  <xs:attribute name="Name"    type="Identifier" use="optional"/>
-  <xs:attribute name="Comment" type="xs:string"  use="optional"/>
+  <xs:attributeGroup ref="NameCommentAttributes"/>
 </xs:complexType>
 
 <xs:complexType name="Subrange">
@@ -104,13 +104,10 @@
 
 <xs:element name="VarDeclaration" type="VarDeclaration"/>
 <xs:complexType name="VarDeclaration">
-  <xs:attribute name="Name"         type="Identifier"  use="required"/>
-  <xs:attribute name="Type"         type="PackageName" use="required"/>
+  <xs:attributeGroup ref="NameTypeCommentAttributes"/>
   <xs:attribute name="ArraySize"    type="xs:string"   use="optional"/>
   <xs:attribute name="InitialValue" type="xs:string"   use="optional"/>
-  <xs:attribute name="Comment"      type="xs:string"   use="optional"/>
 </xs:complexType>
-
 
 <xs:element name="SubrangeVarDeclaration" type="SubrangeVarDeclaration"/>
 <xs:complexType name="SubrangeVarDeclaration">


### PR DESCRIPTION
This adds further xsd improvements in form of attribute groups for reusable sets of attributes (e.g., name and comment)

FYI @franz-hoepfinger-4diac 